### PR TITLE
Use same size for initial capacity of Builder in transformations

### DIFF
--- a/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/ImmutableArrayExtensionsGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/ImmutableArrayExtensionsGenerator.kt
@@ -186,10 +186,10 @@ private fun FileSpec.Builder.addFilterNotNull() {
 
             if (baseType == GENERIC) {
                 jvmName("immutableArrayFilterNotNull")
-                statement("val result = ${baseType.generatedClassName}.Builder<%T>()", nonNullType)
+                statement("val result = ${baseType.generatedClassName}.Builder<%T>(size)", nonNullType)
             } else {
                 jvmName("immutableArrayFilterNotNull_${baseType.typeClass.simpleName}")
-                statement("val result = ${baseType.generatedClassName}.Builder()")
+                statement("val result = ${baseType.generatedClassName}.Builder(size)")
             }
             controlFlow("forEach { value ->") {
                 controlFlow("if (value != null)") {

--- a/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/ImmutableArrayGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/ImmutableArrayGenerator.kt
@@ -734,9 +734,9 @@ private fun TypeSpec.Builder.addFilter(baseType: BaseType) {
         returns = baseType.getGeneratedTypeName(),
     ) {
         if (baseType == GENERIC) {
-            statement("val result = Builder<%T>()", baseType.type)
+            statement("val result = Builder<%T>(size)", baseType.type)
         } else {
-            statement("val result = Builder()")
+            statement("val result = Builder(size)")
         }
         controlFlow("for (element in values)") {
             controlFlow("if (predicate(element))") {
@@ -765,9 +765,9 @@ private fun TypeSpec.Builder.addFilterIndexed(baseType: BaseType) {
         returns = baseType.getGeneratedTypeName(),
     ) {
         if (baseType == GENERIC) {
-            statement("val result = Builder<%T>()", baseType.type)
+            statement("val result = Builder<%T>(size)", baseType.type)
         } else {
-            statement("val result = Builder()")
+            statement("val result = Builder(size)")
         }
         controlFlow("forEachIndexed { index, element ->") {
             controlFlow("if (predicate(index, element))") {
@@ -789,9 +789,9 @@ private fun TypeSpec.Builder.addFilterNot(baseType: BaseType) {
         returns = baseType.getGeneratedTypeName(),
     ) {
         if (baseType == GENERIC) {
-            statement("val result = Builder<%T>()", baseType.type)
+            statement("val result = Builder<%T>(size)", baseType.type)
         } else {
-            statement("val result = Builder()")
+            statement("val result = Builder(size)")
         }
         controlFlow("for (element in values)") {
             controlFlow("if (!predicate(element))") {

--- a/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/multiplicativeSpecializations/FlatMapIndexedSpecializationGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/multiplicativeSpecializations/FlatMapIndexedSpecializationGenerator.kt
@@ -55,9 +55,9 @@ private fun FileSpec.Builder.addFlatMapIndexedFunction(fromType: BaseType, toTyp
         addGenericTypes(fromType.type, mappedType)
 
         if (toType == BaseType.GENERIC) {
-            statement("val builder = ${toType.generatedClassName}.Builder<%T>()", mappedType)
+            statement("val builder = ${toType.generatedClassName}.Builder<%T>(size)", mappedType)
         } else {
-            statement("val builder = ${toType.generatedClassName}.Builder()")
+            statement("val builder = ${toType.generatedClassName}.Builder(size)")
         }
         statement("forEachIndexed { index, element -> builder.addAll(transform(index, element)) }")
         statement("return builder.build()")

--- a/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/multiplicativeSpecializations/FlatMapSpecializationGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/multiplicativeSpecializations/FlatMapSpecializationGenerator.kt
@@ -52,9 +52,9 @@ private fun FileSpec.Builder.addFlatMapFunction(fromType: BaseType, toType: Base
         addGenericTypes(fromType.type, mappedType)
 
         if (toType == BaseType.GENERIC) {
-            statement("val builder = ${toType.generatedClassName}.Builder<%T>()", mappedType)
+            statement("val builder = ${toType.generatedClassName}.Builder<%T>(size)", mappedType)
         } else {
-            statement("val builder = ${toType.generatedClassName}.Builder()")
+            statement("val builder = ${toType.generatedClassName}.Builder(size)")
         }
         statement("forEach { builder.addAll(transform(it)) }")
         statement("return builder.build()")

--- a/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/multiplicativeSpecializations/MapIndexedNotNullSpecializationGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/multiplicativeSpecializations/MapIndexedNotNullSpecializationGenerator.kt
@@ -51,9 +51,9 @@ private fun FileSpec.Builder.addMapIndexedNotNullFunction(fromType: BaseType, to
         addGenericTypes(fromType.type, mappedType)
 
         if (toType == BaseType.GENERIC) {
-            statement("val builder = ${toType.generatedClassName}.Builder<%T>()", mappedType)
+            statement("val builder = ${toType.generatedClassName}.Builder<%T>(size)", mappedType)
         } else {
-            statement("val builder = ${toType.generatedClassName}.Builder()")
+            statement("val builder = ${toType.generatedClassName}.Builder(size)")
         }
         controlFlow("forEachIndexed { index, element ->") {
             statement("transform(index, element)?.let { builder.add(it) }")

--- a/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/multiplicativeSpecializations/MapNotNullSpecializationGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/multiplicativeSpecializations/MapNotNullSpecializationGenerator.kt
@@ -46,9 +46,9 @@ private fun FileSpec.Builder.addMapNotNullFunction(fromType: BaseType, toType: B
         addGenericTypes(fromType.type, mappedType)
 
         if (toType == BaseType.GENERIC) {
-            statement("val builder = ${toType.generatedClassName}.Builder<%T>()", mappedType)
+            statement("val builder = ${toType.generatedClassName}.Builder<%T>(size)", mappedType)
         } else {
-            statement("val builder = ${toType.generatedClassName}.Builder()")
+            statement("val builder = ${toType.generatedClassName}.Builder(size)")
         }
         controlFlow("forEach { element ->") {
             statement("transform(element)?.let { builder.add(it) }")

--- a/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/immutableArraysToStandardCollections/TransformationsToMapFileGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/immutableArraysToStandardCollections/TransformationsToMapFileGenerator.kt
@@ -156,14 +156,14 @@ private fun FileSpec.Builder.addGroupBy() {
                 statement("val key = keySelector(element)")
                 if (baseType == BaseType.GENERIC) {
                     statement(
-                        "val builder = result.getOrPut(key) { ${baseType.generatedClassName}.Builder<%T>() } " +
+                        "val builder = result.getOrPut(key) { ${baseType.generatedClassName}.Builder<%T>(size) } " +
                             "as ${baseType.generatedClassName}.Builder<%T>",
                         baseType.type,
                         baseType.type,
                     )
                 } else {
                     statement(
-                        "val builder = result.getOrPut(key) { ${baseType.generatedClassName}.Builder() } " +
+                        "val builder = result.getOrPut(key) { ${baseType.generatedClassName}.Builder(size) } " +
                             "as ${baseType.generatedClassName}.Builder",
                     )
                 }

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArray.kt
@@ -423,7 +423,7 @@ public value class ImmutableArray<out T> @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filter(predicate: (element: T) -> Boolean): ImmutableArray<T> {
-        val result = Builder<T>()
+        val result = Builder<T>(size)
         for (element in values) {
             if (predicate(element)) {
                 result.add(element)
@@ -438,7 +438,7 @@ public value class ImmutableArray<out T> @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filterIndexed(predicate: (index: Int, element: T) -> Boolean): ImmutableArray<T> {
-        val result = Builder<T>()
+        val result = Builder<T>(size)
         forEachIndexed { index, element ->
             if (predicate(index, element)) {
                 result.add(element)
@@ -453,7 +453,7 @@ public value class ImmutableArray<out T> @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
     public inline fun filterNot(predicate: (element: T) -> Boolean): ImmutableArray<T> {
-        val result = Builder<T>()
+        val result = Builder<T>(size)
         for (element in values) {
             if (!predicate(element)) {
                 result.add(element)

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrays.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrays.kt
@@ -477,7 +477,7 @@ public inline fun ImmutableDoubleArray.getOrElse(index: Int, defaultValue: (inde
 @JvmName("immutableArrayFilterNotNull")
 @Suppress("UNCHECKED_CAST")
 public fun <T : Any> ImmutableArray<T?>.filterNotNull(): ImmutableArray<T> {
-    val result = ImmutableArray.Builder<T>()
+    val result = ImmutableArray.Builder<T>(size)
     forEach { value ->
         if (value != null) {
             result.add(value)
@@ -493,7 +493,7 @@ public fun <T : Any> ImmutableArray<T?>.filterNotNull(): ImmutableArray<T> {
  */
 @JvmName("immutableArrayFilterNotNull_Boolean")
 public fun ImmutableArray<Boolean?>.filterNotNull(): ImmutableBooleanArray {
-    val result = ImmutableBooleanArray.Builder()
+    val result = ImmutableBooleanArray.Builder(size)
     forEach { value ->
         if (value != null) {
             result.add(value)
@@ -507,7 +507,7 @@ public fun ImmutableArray<Boolean?>.filterNotNull(): ImmutableBooleanArray {
  */
 @JvmName("immutableArrayFilterNotNull_Byte")
 public fun ImmutableArray<Byte?>.filterNotNull(): ImmutableByteArray {
-    val result = ImmutableByteArray.Builder()
+    val result = ImmutableByteArray.Builder(size)
     forEach { value ->
         if (value != null) {
             result.add(value)
@@ -521,7 +521,7 @@ public fun ImmutableArray<Byte?>.filterNotNull(): ImmutableByteArray {
  */
 @JvmName("immutableArrayFilterNotNull_Char")
 public fun ImmutableArray<Char?>.filterNotNull(): ImmutableCharArray {
-    val result = ImmutableCharArray.Builder()
+    val result = ImmutableCharArray.Builder(size)
     forEach { value ->
         if (value != null) {
             result.add(value)
@@ -535,7 +535,7 @@ public fun ImmutableArray<Char?>.filterNotNull(): ImmutableCharArray {
  */
 @JvmName("immutableArrayFilterNotNull_Short")
 public fun ImmutableArray<Short?>.filterNotNull(): ImmutableShortArray {
-    val result = ImmutableShortArray.Builder()
+    val result = ImmutableShortArray.Builder(size)
     forEach { value ->
         if (value != null) {
             result.add(value)
@@ -549,7 +549,7 @@ public fun ImmutableArray<Short?>.filterNotNull(): ImmutableShortArray {
  */
 @JvmName("immutableArrayFilterNotNull_Int")
 public fun ImmutableArray<Int?>.filterNotNull(): ImmutableIntArray {
-    val result = ImmutableIntArray.Builder()
+    val result = ImmutableIntArray.Builder(size)
     forEach { value ->
         if (value != null) {
             result.add(value)
@@ -563,7 +563,7 @@ public fun ImmutableArray<Int?>.filterNotNull(): ImmutableIntArray {
  */
 @JvmName("immutableArrayFilterNotNull_Long")
 public fun ImmutableArray<Long?>.filterNotNull(): ImmutableLongArray {
-    val result = ImmutableLongArray.Builder()
+    val result = ImmutableLongArray.Builder(size)
     forEach { value ->
         if (value != null) {
             result.add(value)
@@ -577,7 +577,7 @@ public fun ImmutableArray<Long?>.filterNotNull(): ImmutableLongArray {
  */
 @JvmName("immutableArrayFilterNotNull_Float")
 public fun ImmutableArray<Float?>.filterNotNull(): ImmutableFloatArray {
-    val result = ImmutableFloatArray.Builder()
+    val result = ImmutableFloatArray.Builder(size)
     forEach { value ->
         if (value != null) {
             result.add(value)
@@ -591,7 +591,7 @@ public fun ImmutableArray<Float?>.filterNotNull(): ImmutableFloatArray {
  */
 @JvmName("immutableArrayFilterNotNull_Double")
 public fun ImmutableArray<Double?>.filterNotNull(): ImmutableDoubleArray {
-    val result = ImmutableDoubleArray.Builder()
+    val result = ImmutableDoubleArray.Builder(size)
     forEach { value ->
         if (value != null) {
             result.add(value)

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableBooleanArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableBooleanArray.kt
@@ -420,7 +420,7 @@ public value class ImmutableBooleanArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filter(predicate: (element: Boolean) -> Boolean): ImmutableBooleanArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (predicate(element)) {
                 result.add(element)
@@ -435,7 +435,7 @@ public value class ImmutableBooleanArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filterIndexed(predicate: (index: Int, element: Boolean) -> Boolean): ImmutableBooleanArray {
-        val result = Builder()
+        val result = Builder(size)
         forEachIndexed { index, element ->
             if (predicate(index, element)) {
                 result.add(element)
@@ -450,7 +450,7 @@ public value class ImmutableBooleanArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
     public inline fun filterNot(predicate: (element: Boolean) -> Boolean): ImmutableBooleanArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (!predicate(element)) {
                 result.add(element)

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableByteArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableByteArray.kt
@@ -421,7 +421,7 @@ public value class ImmutableByteArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filter(predicate: (element: Byte) -> Boolean): ImmutableByteArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (predicate(element)) {
                 result.add(element)
@@ -436,7 +436,7 @@ public value class ImmutableByteArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filterIndexed(predicate: (index: Int, element: Byte) -> Boolean): ImmutableByteArray {
-        val result = Builder()
+        val result = Builder(size)
         forEachIndexed { index, element ->
             if (predicate(index, element)) {
                 result.add(element)
@@ -451,7 +451,7 @@ public value class ImmutableByteArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
     public inline fun filterNot(predicate: (element: Byte) -> Boolean): ImmutableByteArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (!predicate(element)) {
                 result.add(element)

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableCharArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableCharArray.kt
@@ -421,7 +421,7 @@ public value class ImmutableCharArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filter(predicate: (element: Char) -> Boolean): ImmutableCharArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (predicate(element)) {
                 result.add(element)
@@ -436,7 +436,7 @@ public value class ImmutableCharArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filterIndexed(predicate: (index: Int, element: Char) -> Boolean): ImmutableCharArray {
-        val result = Builder()
+        val result = Builder(size)
         forEachIndexed { index, element ->
             if (predicate(index, element)) {
                 result.add(element)
@@ -451,7 +451,7 @@ public value class ImmutableCharArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
     public inline fun filterNot(predicate: (element: Char) -> Boolean): ImmutableCharArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (!predicate(element)) {
                 result.add(element)

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableDoubleArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableDoubleArray.kt
@@ -420,7 +420,7 @@ public value class ImmutableDoubleArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filter(predicate: (element: Double) -> Boolean): ImmutableDoubleArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (predicate(element)) {
                 result.add(element)
@@ -435,7 +435,7 @@ public value class ImmutableDoubleArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filterIndexed(predicate: (index: Int, element: Double) -> Boolean): ImmutableDoubleArray {
-        val result = Builder()
+        val result = Builder(size)
         forEachIndexed { index, element ->
             if (predicate(index, element)) {
                 result.add(element)
@@ -450,7 +450,7 @@ public value class ImmutableDoubleArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
     public inline fun filterNot(predicate: (element: Double) -> Boolean): ImmutableDoubleArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (!predicate(element)) {
                 result.add(element)

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableFloatArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableFloatArray.kt
@@ -420,7 +420,7 @@ public value class ImmutableFloatArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filter(predicate: (element: Float) -> Boolean): ImmutableFloatArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (predicate(element)) {
                 result.add(element)
@@ -435,7 +435,7 @@ public value class ImmutableFloatArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filterIndexed(predicate: (index: Int, element: Float) -> Boolean): ImmutableFloatArray {
-        val result = Builder()
+        val result = Builder(size)
         forEachIndexed { index, element ->
             if (predicate(index, element)) {
                 result.add(element)
@@ -450,7 +450,7 @@ public value class ImmutableFloatArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
     public inline fun filterNot(predicate: (element: Float) -> Boolean): ImmutableFloatArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (!predicate(element)) {
                 result.add(element)

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableIntArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableIntArray.kt
@@ -420,7 +420,7 @@ public value class ImmutableIntArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filter(predicate: (element: Int) -> Boolean): ImmutableIntArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (predicate(element)) {
                 result.add(element)
@@ -435,7 +435,7 @@ public value class ImmutableIntArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filterIndexed(predicate: (index: Int, element: Int) -> Boolean): ImmutableIntArray {
-        val result = Builder()
+        val result = Builder(size)
         forEachIndexed { index, element ->
             if (predicate(index, element)) {
                 result.add(element)
@@ -450,7 +450,7 @@ public value class ImmutableIntArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
     public inline fun filterNot(predicate: (element: Int) -> Boolean): ImmutableIntArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (!predicate(element)) {
                 result.add(element)

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableLongArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableLongArray.kt
@@ -420,7 +420,7 @@ public value class ImmutableLongArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filter(predicate: (element: Long) -> Boolean): ImmutableLongArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (predicate(element)) {
                 result.add(element)
@@ -435,7 +435,7 @@ public value class ImmutableLongArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filterIndexed(predicate: (index: Int, element: Long) -> Boolean): ImmutableLongArray {
-        val result = Builder()
+        val result = Builder(size)
         forEachIndexed { index, element ->
             if (predicate(index, element)) {
                 result.add(element)
@@ -450,7 +450,7 @@ public value class ImmutableLongArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
     public inline fun filterNot(predicate: (element: Long) -> Boolean): ImmutableLongArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (!predicate(element)) {
                 result.add(element)

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableShortArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableShortArray.kt
@@ -421,7 +421,7 @@ public value class ImmutableShortArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filter(predicate: (element: Short) -> Boolean): ImmutableShortArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (predicate(element)) {
                 result.add(element)
@@ -436,7 +436,7 @@ public value class ImmutableShortArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
     public inline fun filterIndexed(predicate: (index: Int, element: Short) -> Boolean): ImmutableShortArray {
-        val result = Builder()
+        val result = Builder(size)
         forEachIndexed { index, element ->
             if (predicate(index, element)) {
                 result.add(element)
@@ -451,7 +451,7 @@ public value class ImmutableShortArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
     public inline fun filterNot(predicate: (element: Short) -> Boolean): ImmutableShortArray {
-        val result = Builder()
+        val result = Builder(size)
         for (element in values) {
             if (!predicate(element)) {
                 result.add(element)

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/multiplicativeSpecializations/FlatMapIndexedSpecializations.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/multiplicativeSpecializations/FlatMapIndexedSpecializations.kt
@@ -43,7 +43,7 @@ public inline fun <T, R> ImmutableArray<T>.flatMapIndexed(
         element: T,
     ) -> Iterable<R>,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -81,7 +81,7 @@ public inline fun <T> ImmutableArray<T>.flatMapIndexed(
         element: T,
     ) -> Iterable<Boolean>,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -119,7 +119,7 @@ public inline fun <T> ImmutableArray<T>.flatMapIndexed(
         element: T,
     ) -> Iterable<Byte>,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -157,7 +157,7 @@ public inline fun <T> ImmutableArray<T>.flatMapIndexed(
         element: T,
     ) -> Iterable<Char>,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -195,7 +195,7 @@ public inline fun <T> ImmutableArray<T>.flatMapIndexed(
         element: T,
     ) -> Iterable<Short>,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -233,7 +233,7 @@ public inline fun <T> ImmutableArray<T>.flatMapIndexed(
         element: T,
     ) -> Iterable<Int>,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -271,7 +271,7 @@ public inline fun <T> ImmutableArray<T>.flatMapIndexed(
         element: T,
     ) -> Iterable<Long>,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -309,7 +309,7 @@ public inline fun <T> ImmutableArray<T>.flatMapIndexed(
         element: T,
     ) -> Iterable<Float>,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -347,7 +347,7 @@ public inline fun <T> ImmutableArray<T>.flatMapIndexed(
         element: T,
     ) -> Iterable<Double>,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -385,7 +385,7 @@ public inline fun <R> ImmutableBooleanArray.flatMapIndexed(
         element: Boolean,
     ) -> Iterable<R>,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -423,7 +423,7 @@ public inline fun ImmutableBooleanArray.flatMapIndexed(
         element: Boolean,
     ) -> Iterable<Boolean>,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -461,7 +461,7 @@ public inline fun ImmutableBooleanArray.flatMapIndexed(
         element: Boolean,
     ) -> Iterable<Byte>,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -499,7 +499,7 @@ public inline fun ImmutableBooleanArray.flatMapIndexed(
         element: Boolean,
     ) -> Iterable<Char>,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -537,7 +537,7 @@ public inline fun ImmutableBooleanArray.flatMapIndexed(
         element: Boolean,
     ) -> Iterable<Short>,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -575,7 +575,7 @@ public inline fun ImmutableBooleanArray.flatMapIndexed(
         element: Boolean,
     ) -> Iterable<Int>,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -613,7 +613,7 @@ public inline fun ImmutableBooleanArray.flatMapIndexed(
         element: Boolean,
     ) -> Iterable<Long>,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -651,7 +651,7 @@ public inline fun ImmutableBooleanArray.flatMapIndexed(
         element: Boolean,
     ) -> Iterable<Float>,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -689,7 +689,7 @@ public inline fun ImmutableBooleanArray.flatMapIndexed(
         element: Boolean,
     ) -> Iterable<Double>,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -727,7 +727,7 @@ public inline fun <R> ImmutableByteArray.flatMapIndexed(
         element: Byte,
     ) -> Iterable<R>,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -765,7 +765,7 @@ public inline fun ImmutableByteArray.flatMapIndexed(
         element: Byte,
     ) -> Iterable<Boolean>,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -803,7 +803,7 @@ public inline fun ImmutableByteArray.flatMapIndexed(
         element: Byte,
     ) -> Iterable<Byte>,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -841,7 +841,7 @@ public inline fun ImmutableByteArray.flatMapIndexed(
         element: Byte,
     ) -> Iterable<Char>,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -879,7 +879,7 @@ public inline fun ImmutableByteArray.flatMapIndexed(
         element: Byte,
     ) -> Iterable<Short>,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -917,7 +917,7 @@ public inline fun ImmutableByteArray.flatMapIndexed(
         element: Byte,
     ) -> Iterable<Int>,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -955,7 +955,7 @@ public inline fun ImmutableByteArray.flatMapIndexed(
         element: Byte,
     ) -> Iterable<Long>,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -993,7 +993,7 @@ public inline fun ImmutableByteArray.flatMapIndexed(
         element: Byte,
     ) -> Iterable<Float>,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1031,7 +1031,7 @@ public inline fun ImmutableByteArray.flatMapIndexed(
         element: Byte,
     ) -> Iterable<Double>,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1069,7 +1069,7 @@ public inline fun <R> ImmutableCharArray.flatMapIndexed(
         element: Char,
     ) -> Iterable<R>,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1107,7 +1107,7 @@ public inline fun ImmutableCharArray.flatMapIndexed(
         element: Char,
     ) -> Iterable<Boolean>,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1145,7 +1145,7 @@ public inline fun ImmutableCharArray.flatMapIndexed(
         element: Char,
     ) -> Iterable<Byte>,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1183,7 +1183,7 @@ public inline fun ImmutableCharArray.flatMapIndexed(
         element: Char,
     ) -> Iterable<Char>,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1221,7 +1221,7 @@ public inline fun ImmutableCharArray.flatMapIndexed(
         element: Char,
     ) -> Iterable<Short>,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1259,7 +1259,7 @@ public inline fun ImmutableCharArray.flatMapIndexed(
         element: Char,
     ) -> Iterable<Int>,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1297,7 +1297,7 @@ public inline fun ImmutableCharArray.flatMapIndexed(
         element: Char,
     ) -> Iterable<Long>,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1335,7 +1335,7 @@ public inline fun ImmutableCharArray.flatMapIndexed(
         element: Char,
     ) -> Iterable<Float>,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1373,7 +1373,7 @@ public inline fun ImmutableCharArray.flatMapIndexed(
         element: Char,
     ) -> Iterable<Double>,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1411,7 +1411,7 @@ public inline fun <R> ImmutableShortArray.flatMapIndexed(
         element: Short,
     ) -> Iterable<R>,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1449,7 +1449,7 @@ public inline fun ImmutableShortArray.flatMapIndexed(
         element: Short,
     ) -> Iterable<Boolean>,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1487,7 +1487,7 @@ public inline fun ImmutableShortArray.flatMapIndexed(
         element: Short,
     ) -> Iterable<Byte>,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1525,7 +1525,7 @@ public inline fun ImmutableShortArray.flatMapIndexed(
         element: Short,
     ) -> Iterable<Char>,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1563,7 +1563,7 @@ public inline fun ImmutableShortArray.flatMapIndexed(
         element: Short,
     ) -> Iterable<Short>,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1601,7 +1601,7 @@ public inline fun ImmutableShortArray.flatMapIndexed(
         element: Short,
     ) -> Iterable<Int>,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1639,7 +1639,7 @@ public inline fun ImmutableShortArray.flatMapIndexed(
         element: Short,
     ) -> Iterable<Long>,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1677,7 +1677,7 @@ public inline fun ImmutableShortArray.flatMapIndexed(
         element: Short,
     ) -> Iterable<Float>,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1715,7 +1715,7 @@ public inline fun ImmutableShortArray.flatMapIndexed(
         element: Short,
     ) -> Iterable<Double>,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1753,7 +1753,7 @@ public inline fun <R> ImmutableIntArray.flatMapIndexed(
         element: Int,
     ) -> Iterable<R>,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1791,7 +1791,7 @@ public inline fun ImmutableIntArray.flatMapIndexed(
         element: Int,
     ) -> Iterable<Boolean>,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1829,7 +1829,7 @@ public inline fun ImmutableIntArray.flatMapIndexed(
         element: Int,
     ) -> Iterable<Byte>,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1867,7 +1867,7 @@ public inline fun ImmutableIntArray.flatMapIndexed(
         element: Int,
     ) -> Iterable<Char>,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1905,7 +1905,7 @@ public inline fun ImmutableIntArray.flatMapIndexed(
         element: Int,
     ) -> Iterable<Short>,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1943,7 +1943,7 @@ public inline fun ImmutableIntArray.flatMapIndexed(
         element: Int,
     ) -> Iterable<Int>,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -1981,7 +1981,7 @@ public inline fun ImmutableIntArray.flatMapIndexed(
         element: Int,
     ) -> Iterable<Long>,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2019,7 +2019,7 @@ public inline fun ImmutableIntArray.flatMapIndexed(
         element: Int,
     ) -> Iterable<Float>,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2057,7 +2057,7 @@ public inline fun ImmutableIntArray.flatMapIndexed(
         element: Int,
     ) -> Iterable<Double>,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2095,7 +2095,7 @@ public inline fun <R> ImmutableLongArray.flatMapIndexed(
         element: Long,
     ) -> Iterable<R>,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2133,7 +2133,7 @@ public inline fun ImmutableLongArray.flatMapIndexed(
         element: Long,
     ) -> Iterable<Boolean>,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2171,7 +2171,7 @@ public inline fun ImmutableLongArray.flatMapIndexed(
         element: Long,
     ) -> Iterable<Byte>,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2209,7 +2209,7 @@ public inline fun ImmutableLongArray.flatMapIndexed(
         element: Long,
     ) -> Iterable<Char>,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2247,7 +2247,7 @@ public inline fun ImmutableLongArray.flatMapIndexed(
         element: Long,
     ) -> Iterable<Short>,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2285,7 +2285,7 @@ public inline fun ImmutableLongArray.flatMapIndexed(
         element: Long,
     ) -> Iterable<Int>,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2323,7 +2323,7 @@ public inline fun ImmutableLongArray.flatMapIndexed(
         element: Long,
     ) -> Iterable<Long>,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2361,7 +2361,7 @@ public inline fun ImmutableLongArray.flatMapIndexed(
         element: Long,
     ) -> Iterable<Float>,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2399,7 +2399,7 @@ public inline fun ImmutableLongArray.flatMapIndexed(
         element: Long,
     ) -> Iterable<Double>,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2437,7 +2437,7 @@ public inline fun <R> ImmutableFloatArray.flatMapIndexed(
         element: Float,
     ) -> Iterable<R>,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2475,7 +2475,7 @@ public inline fun ImmutableFloatArray.flatMapIndexed(
         element: Float,
     ) -> Iterable<Boolean>,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2513,7 +2513,7 @@ public inline fun ImmutableFloatArray.flatMapIndexed(
         element: Float,
     ) -> Iterable<Byte>,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2551,7 +2551,7 @@ public inline fun ImmutableFloatArray.flatMapIndexed(
         element: Float,
     ) -> Iterable<Char>,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2589,7 +2589,7 @@ public inline fun ImmutableFloatArray.flatMapIndexed(
         element: Float,
     ) -> Iterable<Short>,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2627,7 +2627,7 @@ public inline fun ImmutableFloatArray.flatMapIndexed(
         element: Float,
     ) -> Iterable<Int>,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2665,7 +2665,7 @@ public inline fun ImmutableFloatArray.flatMapIndexed(
         element: Float,
     ) -> Iterable<Long>,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2703,7 +2703,7 @@ public inline fun ImmutableFloatArray.flatMapIndexed(
         element: Float,
     ) -> Iterable<Float>,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2741,7 +2741,7 @@ public inline fun ImmutableFloatArray.flatMapIndexed(
         element: Float,
     ) -> Iterable<Double>,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2779,7 +2779,7 @@ public inline fun <R> ImmutableDoubleArray.flatMapIndexed(
         element: Double,
     ) -> Iterable<R>,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2817,7 +2817,7 @@ public inline fun ImmutableDoubleArray.flatMapIndexed(
         element: Double,
     ) -> Iterable<Boolean>,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2855,7 +2855,7 @@ public inline fun ImmutableDoubleArray.flatMapIndexed(
         element: Double,
     ) -> Iterable<Byte>,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2893,7 +2893,7 @@ public inline fun ImmutableDoubleArray.flatMapIndexed(
         element: Double,
     ) -> Iterable<Char>,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2931,7 +2931,7 @@ public inline fun ImmutableDoubleArray.flatMapIndexed(
         element: Double,
     ) -> Iterable<Short>,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -2969,7 +2969,7 @@ public inline fun ImmutableDoubleArray.flatMapIndexed(
         element: Double,
     ) -> Iterable<Int>,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -3007,7 +3007,7 @@ public inline fun ImmutableDoubleArray.flatMapIndexed(
         element: Double,
     ) -> Iterable<Long>,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -3045,7 +3045,7 @@ public inline fun ImmutableDoubleArray.flatMapIndexed(
         element: Double,
     ) -> Iterable<Float>,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }
@@ -3083,7 +3083,7 @@ public inline fun ImmutableDoubleArray.flatMapIndexed(
         element: Double,
     ) -> Iterable<Double>,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element -> builder.addAll(transform(index, element)) }
     return builder.build()
 }

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/multiplicativeSpecializations/FlatMapSpecializations.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/multiplicativeSpecializations/FlatMapSpecializations.kt
@@ -38,7 +38,7 @@ import kotlin.jvm.JvmName
 @JvmName("flatMapAnyIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <T, R> ImmutableArray<T>.flatMap(transform: (element: T) -> Iterable<R>): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -66,7 +66,7 @@ public inline fun <T, R> ImmutableArray<T>.flatMap(transform: (element: T) -> Im
 @JvmName("flatMapBooleanIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Iterable<Boolean>): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -94,7 +94,7 @@ public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Immut
 @JvmName("flatMapByteIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Iterable<Byte>): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -122,7 +122,7 @@ public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Immut
 @JvmName("flatMapCharIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Iterable<Char>): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -150,7 +150,7 @@ public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Immut
 @JvmName("flatMapShortIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Iterable<Short>): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -178,7 +178,7 @@ public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Immut
 @JvmName("flatMapIntIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Iterable<Int>): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -206,7 +206,7 @@ public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Immut
 @JvmName("flatMapLongIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Iterable<Long>): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -234,7 +234,7 @@ public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Immut
 @JvmName("flatMapFloatIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Iterable<Float>): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -262,7 +262,7 @@ public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Immut
 @JvmName("flatMapDoubleIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Iterable<Double>): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -290,7 +290,7 @@ public inline fun <T> ImmutableArray<T>.flatMap(transform: (element: T) -> Immut
 @JvmName("flatMapAnyIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableBooleanArray.flatMap(transform: (element: Boolean) -> Iterable<R>): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -318,7 +318,7 @@ public inline fun <R> ImmutableBooleanArray.flatMap(transform: (element: Boolean
 @JvmName("flatMapBooleanIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) -> Iterable<Boolean>): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -346,7 +346,7 @@ public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) ->
 @JvmName("flatMapByteIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) -> Iterable<Byte>): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -374,7 +374,7 @@ public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) ->
 @JvmName("flatMapCharIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) -> Iterable<Char>): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -402,7 +402,7 @@ public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) ->
 @JvmName("flatMapShortIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) -> Iterable<Short>): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -430,7 +430,7 @@ public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) ->
 @JvmName("flatMapIntIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) -> Iterable<Int>): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -458,7 +458,7 @@ public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) ->
 @JvmName("flatMapLongIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) -> Iterable<Long>): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -486,7 +486,7 @@ public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) ->
 @JvmName("flatMapFloatIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) -> Iterable<Float>): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -514,7 +514,7 @@ public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) ->
 @JvmName("flatMapDoubleIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) -> Iterable<Double>): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -542,7 +542,7 @@ public inline fun ImmutableBooleanArray.flatMap(transform: (element: Boolean) ->
 @JvmName("flatMapAnyIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableByteArray.flatMap(transform: (element: Byte) -> Iterable<R>): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -570,7 +570,7 @@ public inline fun <R> ImmutableByteArray.flatMap(transform: (element: Byte) -> I
 @JvmName("flatMapBooleanIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Iterable<Boolean>): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -598,7 +598,7 @@ public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Immut
 @JvmName("flatMapByteIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Iterable<Byte>): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -626,7 +626,7 @@ public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Immut
 @JvmName("flatMapCharIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Iterable<Char>): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -654,7 +654,7 @@ public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Immut
 @JvmName("flatMapShortIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Iterable<Short>): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -682,7 +682,7 @@ public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Immut
 @JvmName("flatMapIntIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Iterable<Int>): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -710,7 +710,7 @@ public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Immut
 @JvmName("flatMapLongIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Iterable<Long>): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -738,7 +738,7 @@ public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Immut
 @JvmName("flatMapFloatIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Iterable<Float>): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -766,7 +766,7 @@ public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Immut
 @JvmName("flatMapDoubleIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Iterable<Double>): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -794,7 +794,7 @@ public inline fun ImmutableByteArray.flatMap(transform: (element: Byte) -> Immut
 @JvmName("flatMapAnyIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableCharArray.flatMap(transform: (element: Char) -> Iterable<R>): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -822,7 +822,7 @@ public inline fun <R> ImmutableCharArray.flatMap(transform: (element: Char) -> I
 @JvmName("flatMapBooleanIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Iterable<Boolean>): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -850,7 +850,7 @@ public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Immut
 @JvmName("flatMapByteIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Iterable<Byte>): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -878,7 +878,7 @@ public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Immut
 @JvmName("flatMapCharIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Iterable<Char>): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -906,7 +906,7 @@ public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Immut
 @JvmName("flatMapShortIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Iterable<Short>): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -934,7 +934,7 @@ public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Immut
 @JvmName("flatMapIntIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Iterable<Int>): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -962,7 +962,7 @@ public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Immut
 @JvmName("flatMapLongIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Iterable<Long>): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -990,7 +990,7 @@ public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Immut
 @JvmName("flatMapFloatIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Iterable<Float>): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1018,7 +1018,7 @@ public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Immut
 @JvmName("flatMapDoubleIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Iterable<Double>): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1046,7 +1046,7 @@ public inline fun ImmutableCharArray.flatMap(transform: (element: Char) -> Immut
 @JvmName("flatMapAnyIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableShortArray.flatMap(transform: (element: Short) -> Iterable<R>): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1074,7 +1074,7 @@ public inline fun <R> ImmutableShortArray.flatMap(transform: (element: Short) ->
 @JvmName("flatMapBooleanIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Iterable<Boolean>): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1102,7 +1102,7 @@ public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Imm
 @JvmName("flatMapByteIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Iterable<Byte>): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1130,7 +1130,7 @@ public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Imm
 @JvmName("flatMapCharIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Iterable<Char>): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1158,7 +1158,7 @@ public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Imm
 @JvmName("flatMapShortIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Iterable<Short>): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1186,7 +1186,7 @@ public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Imm
 @JvmName("flatMapIntIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Iterable<Int>): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1214,7 +1214,7 @@ public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Imm
 @JvmName("flatMapLongIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Iterable<Long>): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1242,7 +1242,7 @@ public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Imm
 @JvmName("flatMapFloatIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Iterable<Float>): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1270,7 +1270,7 @@ public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Imm
 @JvmName("flatMapDoubleIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Iterable<Double>): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1298,7 +1298,7 @@ public inline fun ImmutableShortArray.flatMap(transform: (element: Short) -> Imm
 @JvmName("flatMapAnyIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableIntArray.flatMap(transform: (element: Int) -> Iterable<R>): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1326,7 +1326,7 @@ public inline fun <R> ImmutableIntArray.flatMap(transform: (element: Int) -> Imm
 @JvmName("flatMapBooleanIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Iterable<Boolean>): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1354,7 +1354,7 @@ public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Immutab
 @JvmName("flatMapByteIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Iterable<Byte>): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1382,7 +1382,7 @@ public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Immutab
 @JvmName("flatMapCharIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Iterable<Char>): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1410,7 +1410,7 @@ public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Immutab
 @JvmName("flatMapShortIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Iterable<Short>): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1438,7 +1438,7 @@ public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Immutab
 @JvmName("flatMapIntIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Iterable<Int>): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1466,7 +1466,7 @@ public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Immutab
 @JvmName("flatMapLongIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Iterable<Long>): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1494,7 +1494,7 @@ public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Immutab
 @JvmName("flatMapFloatIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Iterable<Float>): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1522,7 +1522,7 @@ public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Immutab
 @JvmName("flatMapDoubleIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Iterable<Double>): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1550,7 +1550,7 @@ public inline fun ImmutableIntArray.flatMap(transform: (element: Int) -> Immutab
 @JvmName("flatMapAnyIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableLongArray.flatMap(transform: (element: Long) -> Iterable<R>): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1578,7 +1578,7 @@ public inline fun <R> ImmutableLongArray.flatMap(transform: (element: Long) -> I
 @JvmName("flatMapBooleanIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Iterable<Boolean>): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1606,7 +1606,7 @@ public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Immut
 @JvmName("flatMapByteIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Iterable<Byte>): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1634,7 +1634,7 @@ public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Immut
 @JvmName("flatMapCharIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Iterable<Char>): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1662,7 +1662,7 @@ public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Immut
 @JvmName("flatMapShortIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Iterable<Short>): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1690,7 +1690,7 @@ public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Immut
 @JvmName("flatMapIntIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Iterable<Int>): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1718,7 +1718,7 @@ public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Immut
 @JvmName("flatMapLongIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Iterable<Long>): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1746,7 +1746,7 @@ public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Immut
 @JvmName("flatMapFloatIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Iterable<Float>): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1774,7 +1774,7 @@ public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Immut
 @JvmName("flatMapDoubleIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Iterable<Double>): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1802,7 +1802,7 @@ public inline fun ImmutableLongArray.flatMap(transform: (element: Long) -> Immut
 @JvmName("flatMapAnyIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableFloatArray.flatMap(transform: (element: Float) -> Iterable<R>): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1830,7 +1830,7 @@ public inline fun <R> ImmutableFloatArray.flatMap(transform: (element: Float) ->
 @JvmName("flatMapBooleanIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Iterable<Boolean>): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1858,7 +1858,7 @@ public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Imm
 @JvmName("flatMapByteIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Iterable<Byte>): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1886,7 +1886,7 @@ public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Imm
 @JvmName("flatMapCharIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Iterable<Char>): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1914,7 +1914,7 @@ public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Imm
 @JvmName("flatMapShortIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Iterable<Short>): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1942,7 +1942,7 @@ public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Imm
 @JvmName("flatMapIntIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Iterable<Int>): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1970,7 +1970,7 @@ public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Imm
 @JvmName("flatMapLongIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Iterable<Long>): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -1998,7 +1998,7 @@ public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Imm
 @JvmName("flatMapFloatIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Iterable<Float>): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -2026,7 +2026,7 @@ public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Imm
 @JvmName("flatMapDoubleIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Iterable<Double>): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -2054,7 +2054,7 @@ public inline fun ImmutableFloatArray.flatMap(transform: (element: Float) -> Imm
 @JvmName("flatMapAnyIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableDoubleArray.flatMap(transform: (element: Double) -> Iterable<R>): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -2082,7 +2082,7 @@ public inline fun <R> ImmutableDoubleArray.flatMap(transform: (element: Double) 
 @JvmName("flatMapBooleanIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> Iterable<Boolean>): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -2110,7 +2110,7 @@ public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> I
 @JvmName("flatMapByteIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> Iterable<Byte>): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -2138,7 +2138,7 @@ public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> I
 @JvmName("flatMapCharIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> Iterable<Char>): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -2166,7 +2166,7 @@ public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> I
 @JvmName("flatMapShortIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> Iterable<Short>): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -2194,7 +2194,7 @@ public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> I
 @JvmName("flatMapIntIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> Iterable<Int>): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -2222,7 +2222,7 @@ public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> I
 @JvmName("flatMapLongIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> Iterable<Long>): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -2250,7 +2250,7 @@ public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> I
 @JvmName("flatMapFloatIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> Iterable<Float>): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }
@@ -2278,7 +2278,7 @@ public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> I
 @JvmName("flatMapDoubleIterable")
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.flatMap(transform: (element: Double) -> Iterable<Double>): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { builder.addAll(transform(it)) }
     return builder.build()
 }

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/multiplicativeSpecializations/MapIndexedNotNullSpecializations.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/multiplicativeSpecializations/MapIndexedNotNullSpecializations.kt
@@ -31,7 +31,7 @@ public inline fun <T, R> ImmutableArray<T>.mapIndexedNotNull(
         element: T,
     ) -> R?,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -49,7 +49,7 @@ public inline fun <T> ImmutableArray<T>.mapIndexedNotNull(
         element: T,
     ) -> Boolean?,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -67,7 +67,7 @@ public inline fun <T> ImmutableArray<T>.mapIndexedNotNull(
         element: T,
     ) -> Byte?,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -85,7 +85,7 @@ public inline fun <T> ImmutableArray<T>.mapIndexedNotNull(
         element: T,
     ) -> Char?,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -103,7 +103,7 @@ public inline fun <T> ImmutableArray<T>.mapIndexedNotNull(
         element: T,
     ) -> Short?,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -121,7 +121,7 @@ public inline fun <T> ImmutableArray<T>.mapIndexedNotNull(
         element: T,
     ) -> Int?,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -139,7 +139,7 @@ public inline fun <T> ImmutableArray<T>.mapIndexedNotNull(
         element: T,
     ) -> Long?,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -157,7 +157,7 @@ public inline fun <T> ImmutableArray<T>.mapIndexedNotNull(
         element: T,
     ) -> Float?,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -175,7 +175,7 @@ public inline fun <T> ImmutableArray<T>.mapIndexedNotNull(
         element: T,
     ) -> Double?,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -193,7 +193,7 @@ public inline fun <R> ImmutableBooleanArray.mapIndexedNotNull(
         element: Boolean,
     ) -> R?,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -211,7 +211,7 @@ public inline fun ImmutableBooleanArray.mapIndexedNotNull(
         element: Boolean,
     ) -> Boolean?,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -229,7 +229,7 @@ public inline fun ImmutableBooleanArray.mapIndexedNotNull(
         element: Boolean,
     ) -> Byte?,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -247,7 +247,7 @@ public inline fun ImmutableBooleanArray.mapIndexedNotNull(
         element: Boolean,
     ) -> Char?,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -265,7 +265,7 @@ public inline fun ImmutableBooleanArray.mapIndexedNotNull(
         element: Boolean,
     ) -> Short?,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -283,7 +283,7 @@ public inline fun ImmutableBooleanArray.mapIndexedNotNull(
         element: Boolean,
     ) -> Int?,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -301,7 +301,7 @@ public inline fun ImmutableBooleanArray.mapIndexedNotNull(
         element: Boolean,
     ) -> Long?,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -319,7 +319,7 @@ public inline fun ImmutableBooleanArray.mapIndexedNotNull(
         element: Boolean,
     ) -> Float?,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -337,7 +337,7 @@ public inline fun ImmutableBooleanArray.mapIndexedNotNull(
         element: Boolean,
     ) -> Double?,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -355,7 +355,7 @@ public inline fun <R> ImmutableByteArray.mapIndexedNotNull(
         element: Byte,
     ) -> R?,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -373,7 +373,7 @@ public inline fun ImmutableByteArray.mapIndexedNotNull(
         element: Byte,
     ) -> Boolean?,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -391,7 +391,7 @@ public inline fun ImmutableByteArray.mapIndexedNotNull(
         element: Byte,
     ) -> Byte?,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -409,7 +409,7 @@ public inline fun ImmutableByteArray.mapIndexedNotNull(
         element: Byte,
     ) -> Char?,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -427,7 +427,7 @@ public inline fun ImmutableByteArray.mapIndexedNotNull(
         element: Byte,
     ) -> Short?,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -445,7 +445,7 @@ public inline fun ImmutableByteArray.mapIndexedNotNull(
         element: Byte,
     ) -> Int?,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -463,7 +463,7 @@ public inline fun ImmutableByteArray.mapIndexedNotNull(
         element: Byte,
     ) -> Long?,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -481,7 +481,7 @@ public inline fun ImmutableByteArray.mapIndexedNotNull(
         element: Byte,
     ) -> Float?,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -499,7 +499,7 @@ public inline fun ImmutableByteArray.mapIndexedNotNull(
         element: Byte,
     ) -> Double?,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -517,7 +517,7 @@ public inline fun <R> ImmutableCharArray.mapIndexedNotNull(
         element: Char,
     ) -> R?,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -535,7 +535,7 @@ public inline fun ImmutableCharArray.mapIndexedNotNull(
         element: Char,
     ) -> Boolean?,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -553,7 +553,7 @@ public inline fun ImmutableCharArray.mapIndexedNotNull(
         element: Char,
     ) -> Byte?,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -571,7 +571,7 @@ public inline fun ImmutableCharArray.mapIndexedNotNull(
         element: Char,
     ) -> Char?,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -589,7 +589,7 @@ public inline fun ImmutableCharArray.mapIndexedNotNull(
         element: Char,
     ) -> Short?,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -607,7 +607,7 @@ public inline fun ImmutableCharArray.mapIndexedNotNull(
         element: Char,
     ) -> Int?,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -625,7 +625,7 @@ public inline fun ImmutableCharArray.mapIndexedNotNull(
         element: Char,
     ) -> Long?,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -643,7 +643,7 @@ public inline fun ImmutableCharArray.mapIndexedNotNull(
         element: Char,
     ) -> Float?,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -661,7 +661,7 @@ public inline fun ImmutableCharArray.mapIndexedNotNull(
         element: Char,
     ) -> Double?,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -679,7 +679,7 @@ public inline fun <R> ImmutableShortArray.mapIndexedNotNull(
         element: Short,
     ) -> R?,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -697,7 +697,7 @@ public inline fun ImmutableShortArray.mapIndexedNotNull(
         element: Short,
     ) -> Boolean?,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -715,7 +715,7 @@ public inline fun ImmutableShortArray.mapIndexedNotNull(
         element: Short,
     ) -> Byte?,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -733,7 +733,7 @@ public inline fun ImmutableShortArray.mapIndexedNotNull(
         element: Short,
     ) -> Char?,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -751,7 +751,7 @@ public inline fun ImmutableShortArray.mapIndexedNotNull(
         element: Short,
     ) -> Short?,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -769,7 +769,7 @@ public inline fun ImmutableShortArray.mapIndexedNotNull(
         element: Short,
     ) -> Int?,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -787,7 +787,7 @@ public inline fun ImmutableShortArray.mapIndexedNotNull(
         element: Short,
     ) -> Long?,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -805,7 +805,7 @@ public inline fun ImmutableShortArray.mapIndexedNotNull(
         element: Short,
     ) -> Float?,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -823,7 +823,7 @@ public inline fun ImmutableShortArray.mapIndexedNotNull(
         element: Short,
     ) -> Double?,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -841,7 +841,7 @@ public inline fun <R> ImmutableIntArray.mapIndexedNotNull(
         element: Int,
     ) -> R?,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -859,7 +859,7 @@ public inline fun ImmutableIntArray.mapIndexedNotNull(
         element: Int,
     ) -> Boolean?,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -877,7 +877,7 @@ public inline fun ImmutableIntArray.mapIndexedNotNull(
         element: Int,
     ) -> Byte?,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -895,7 +895,7 @@ public inline fun ImmutableIntArray.mapIndexedNotNull(
         element: Int,
     ) -> Char?,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -913,7 +913,7 @@ public inline fun ImmutableIntArray.mapIndexedNotNull(
         element: Int,
     ) -> Short?,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -931,7 +931,7 @@ public inline fun ImmutableIntArray.mapIndexedNotNull(
         element: Int,
     ) -> Int?,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -949,7 +949,7 @@ public inline fun ImmutableIntArray.mapIndexedNotNull(
         element: Int,
     ) -> Long?,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -967,7 +967,7 @@ public inline fun ImmutableIntArray.mapIndexedNotNull(
         element: Int,
     ) -> Float?,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -985,7 +985,7 @@ public inline fun ImmutableIntArray.mapIndexedNotNull(
         element: Int,
     ) -> Double?,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1003,7 +1003,7 @@ public inline fun <R> ImmutableLongArray.mapIndexedNotNull(
         element: Long,
     ) -> R?,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1021,7 +1021,7 @@ public inline fun ImmutableLongArray.mapIndexedNotNull(
         element: Long,
     ) -> Boolean?,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1039,7 +1039,7 @@ public inline fun ImmutableLongArray.mapIndexedNotNull(
         element: Long,
     ) -> Byte?,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1057,7 +1057,7 @@ public inline fun ImmutableLongArray.mapIndexedNotNull(
         element: Long,
     ) -> Char?,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1075,7 +1075,7 @@ public inline fun ImmutableLongArray.mapIndexedNotNull(
         element: Long,
     ) -> Short?,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1093,7 +1093,7 @@ public inline fun ImmutableLongArray.mapIndexedNotNull(
         element: Long,
     ) -> Int?,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1111,7 +1111,7 @@ public inline fun ImmutableLongArray.mapIndexedNotNull(
         element: Long,
     ) -> Long?,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1129,7 +1129,7 @@ public inline fun ImmutableLongArray.mapIndexedNotNull(
         element: Long,
     ) -> Float?,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1147,7 +1147,7 @@ public inline fun ImmutableLongArray.mapIndexedNotNull(
         element: Long,
     ) -> Double?,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1165,7 +1165,7 @@ public inline fun <R> ImmutableFloatArray.mapIndexedNotNull(
         element: Float,
     ) -> R?,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1183,7 +1183,7 @@ public inline fun ImmutableFloatArray.mapIndexedNotNull(
         element: Float,
     ) -> Boolean?,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1201,7 +1201,7 @@ public inline fun ImmutableFloatArray.mapIndexedNotNull(
         element: Float,
     ) -> Byte?,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1219,7 +1219,7 @@ public inline fun ImmutableFloatArray.mapIndexedNotNull(
         element: Float,
     ) -> Char?,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1237,7 +1237,7 @@ public inline fun ImmutableFloatArray.mapIndexedNotNull(
         element: Float,
     ) -> Short?,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1255,7 +1255,7 @@ public inline fun ImmutableFloatArray.mapIndexedNotNull(
         element: Float,
     ) -> Int?,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1273,7 +1273,7 @@ public inline fun ImmutableFloatArray.mapIndexedNotNull(
         element: Float,
     ) -> Long?,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1291,7 +1291,7 @@ public inline fun ImmutableFloatArray.mapIndexedNotNull(
         element: Float,
     ) -> Float?,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1309,7 +1309,7 @@ public inline fun ImmutableFloatArray.mapIndexedNotNull(
         element: Float,
     ) -> Double?,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1327,7 +1327,7 @@ public inline fun <R> ImmutableDoubleArray.mapIndexedNotNull(
         element: Double,
     ) -> R?,
 ): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1345,7 +1345,7 @@ public inline fun ImmutableDoubleArray.mapIndexedNotNull(
         element: Double,
     ) -> Boolean?,
 ): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1363,7 +1363,7 @@ public inline fun ImmutableDoubleArray.mapIndexedNotNull(
         element: Double,
     ) -> Byte?,
 ): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1381,7 +1381,7 @@ public inline fun ImmutableDoubleArray.mapIndexedNotNull(
         element: Double,
     ) -> Char?,
 ): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1399,7 +1399,7 @@ public inline fun ImmutableDoubleArray.mapIndexedNotNull(
         element: Double,
     ) -> Short?,
 ): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1417,7 +1417,7 @@ public inline fun ImmutableDoubleArray.mapIndexedNotNull(
         element: Double,
     ) -> Int?,
 ): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1435,7 +1435,7 @@ public inline fun ImmutableDoubleArray.mapIndexedNotNull(
         element: Double,
     ) -> Long?,
 ): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1453,7 +1453,7 @@ public inline fun ImmutableDoubleArray.mapIndexedNotNull(
         element: Double,
     ) -> Float?,
 ): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }
@@ -1471,7 +1471,7 @@ public inline fun ImmutableDoubleArray.mapIndexedNotNull(
         element: Double,
     ) -> Double?,
 ): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEachIndexed { index, element ->
         transform(index, element)?.let { builder.add(it) }
     }

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/multiplicativeSpecializations/MapNotNullSpecializations.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/multiplicativeSpecializations/MapNotNullSpecializations.kt
@@ -25,7 +25,7 @@ import kotlin.Short
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <T, R> ImmutableArray<T>.mapNotNull(transform: (element: T) -> R?): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -37,7 +37,7 @@ public inline fun <T, R> ImmutableArray<T>.mapNotNull(transform: (element: T) ->
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Boolean?): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -49,7 +49,7 @@ public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Bo
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Byte?): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -61,7 +61,7 @@ public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> By
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Char?): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -73,7 +73,7 @@ public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Ch
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Short?): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -85,7 +85,7 @@ public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Sh
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Int?): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -97,7 +97,7 @@ public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> In
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Long?): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -109,7 +109,7 @@ public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Lo
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Float?): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -121,7 +121,7 @@ public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Fl
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Double?): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -133,7 +133,7 @@ public inline fun <T> ImmutableArray<T>.mapNotNull(transform: (element: T) -> Do
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableBooleanArray.mapNotNull(transform: (element: Boolean) -> R?): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -145,7 +145,7 @@ public inline fun <R> ImmutableBooleanArray.mapNotNull(transform: (element: Bool
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean) -> Boolean?): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -157,7 +157,7 @@ public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean)
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean) -> Byte?): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -169,7 +169,7 @@ public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean)
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean) -> Char?): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -181,7 +181,7 @@ public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean)
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean) -> Short?): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -193,7 +193,7 @@ public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean)
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean) -> Int?): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -205,7 +205,7 @@ public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean)
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean) -> Long?): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -217,7 +217,7 @@ public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean)
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean) -> Float?): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -229,7 +229,7 @@ public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean)
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean) -> Double?): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -241,7 +241,7 @@ public inline fun ImmutableBooleanArray.mapNotNull(transform: (element: Boolean)
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableByteArray.mapNotNull(transform: (element: Byte) -> R?): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -253,7 +253,7 @@ public inline fun <R> ImmutableByteArray.mapNotNull(transform: (element: Byte) -
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Boolean?): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -265,7 +265,7 @@ public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Bo
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Byte?): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -277,7 +277,7 @@ public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> By
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Char?): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -289,7 +289,7 @@ public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Ch
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Short?): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -301,7 +301,7 @@ public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Sh
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Int?): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -313,7 +313,7 @@ public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> In
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Long?): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -325,7 +325,7 @@ public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Lo
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Float?): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -337,7 +337,7 @@ public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Fl
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Double?): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -349,7 +349,7 @@ public inline fun ImmutableByteArray.mapNotNull(transform: (element: Byte) -> Do
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableCharArray.mapNotNull(transform: (element: Char) -> R?): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -361,7 +361,7 @@ public inline fun <R> ImmutableCharArray.mapNotNull(transform: (element: Char) -
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Boolean?): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -373,7 +373,7 @@ public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Bo
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Byte?): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -385,7 +385,7 @@ public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> By
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Char?): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -397,7 +397,7 @@ public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Ch
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Short?): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -409,7 +409,7 @@ public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Sh
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Int?): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -421,7 +421,7 @@ public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> In
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Long?): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -433,7 +433,7 @@ public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Lo
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Float?): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -445,7 +445,7 @@ public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Fl
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Double?): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -457,7 +457,7 @@ public inline fun ImmutableCharArray.mapNotNull(transform: (element: Char) -> Do
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableShortArray.mapNotNull(transform: (element: Short) -> R?): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -469,7 +469,7 @@ public inline fun <R> ImmutableShortArray.mapNotNull(transform: (element: Short)
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> Boolean?): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -481,7 +481,7 @@ public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> Byte?): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -493,7 +493,7 @@ public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> Char?): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -505,7 +505,7 @@ public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> Short?): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -517,7 +517,7 @@ public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> Int?): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -529,7 +529,7 @@ public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> Long?): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -541,7 +541,7 @@ public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> Float?): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -553,7 +553,7 @@ public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> Double?): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -565,7 +565,7 @@ public inline fun ImmutableShortArray.mapNotNull(transform: (element: Short) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableIntArray.mapNotNull(transform: (element: Int) -> R?): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -577,7 +577,7 @@ public inline fun <R> ImmutableIntArray.mapNotNull(transform: (element: Int) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Boolean?): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -589,7 +589,7 @@ public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Bool
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Byte?): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -601,7 +601,7 @@ public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Byte
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Char?): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -613,7 +613,7 @@ public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Char
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Short?): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -625,7 +625,7 @@ public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Shor
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Int?): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -637,7 +637,7 @@ public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Int?
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Long?): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -649,7 +649,7 @@ public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Long
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Float?): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -661,7 +661,7 @@ public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Floa
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Double?): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -673,7 +673,7 @@ public inline fun ImmutableIntArray.mapNotNull(transform: (element: Int) -> Doub
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableLongArray.mapNotNull(transform: (element: Long) -> R?): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -685,7 +685,7 @@ public inline fun <R> ImmutableLongArray.mapNotNull(transform: (element: Long) -
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Boolean?): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -697,7 +697,7 @@ public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Bo
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Byte?): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -709,7 +709,7 @@ public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> By
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Char?): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -721,7 +721,7 @@ public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Ch
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Short?): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -733,7 +733,7 @@ public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Sh
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Int?): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -745,7 +745,7 @@ public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> In
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Long?): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -757,7 +757,7 @@ public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Lo
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Float?): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -769,7 +769,7 @@ public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Fl
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Double?): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -781,7 +781,7 @@ public inline fun ImmutableLongArray.mapNotNull(transform: (element: Long) -> Do
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableFloatArray.mapNotNull(transform: (element: Float) -> R?): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -793,7 +793,7 @@ public inline fun <R> ImmutableFloatArray.mapNotNull(transform: (element: Float)
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> Boolean?): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -805,7 +805,7 @@ public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> Byte?): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -817,7 +817,7 @@ public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> Char?): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -829,7 +829,7 @@ public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> Short?): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -841,7 +841,7 @@ public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> Int?): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -853,7 +853,7 @@ public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> Long?): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -865,7 +865,7 @@ public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> Float?): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -877,7 +877,7 @@ public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> Double?): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -889,7 +889,7 @@ public inline fun ImmutableFloatArray.mapNotNull(transform: (element: Float) -> 
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun <R> ImmutableDoubleArray.mapNotNull(transform: (element: Double) -> R?): ImmutableArray<R> {
-    val builder = ImmutableArray.Builder<R>()
+    val builder = ImmutableArray.Builder<R>(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -901,7 +901,7 @@ public inline fun <R> ImmutableDoubleArray.mapNotNull(transform: (element: Doubl
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -> Boolean?): ImmutableBooleanArray {
-    val builder = ImmutableBooleanArray.Builder()
+    val builder = ImmutableBooleanArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -913,7 +913,7 @@ public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -> Byte?): ImmutableByteArray {
-    val builder = ImmutableByteArray.Builder()
+    val builder = ImmutableByteArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -925,7 +925,7 @@ public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -> Char?): ImmutableCharArray {
-    val builder = ImmutableCharArray.Builder()
+    val builder = ImmutableCharArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -937,7 +937,7 @@ public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -> Short?): ImmutableShortArray {
-    val builder = ImmutableShortArray.Builder()
+    val builder = ImmutableShortArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -949,7 +949,7 @@ public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -> Int?): ImmutableIntArray {
-    val builder = ImmutableIntArray.Builder()
+    val builder = ImmutableIntArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -961,7 +961,7 @@ public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -> Long?): ImmutableLongArray {
-    val builder = ImmutableLongArray.Builder()
+    val builder = ImmutableLongArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -973,7 +973,7 @@ public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -> Float?): ImmutableFloatArray {
-    val builder = ImmutableFloatArray.Builder()
+    val builder = ImmutableFloatArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }
@@ -985,7 +985,7 @@ public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -
  */
 @OverloadResolutionByLambdaReturnType
 public inline fun ImmutableDoubleArray.mapNotNull(transform: (element: Double) -> Double?): ImmutableDoubleArray {
-    val builder = ImmutableDoubleArray.Builder()
+    val builder = ImmutableDoubleArray.Builder(size)
     forEach { element ->
         transform(element)?.let { builder.add(it) }
     }

--- a/immutable-arrays/transformations-to-standard-collections/src/main/kotlin/com/danrusu/pods4k/immutableArrays/TransformationsToMap.kt
+++ b/immutable-arrays/transformations-to-standard-collections/src/main/kotlin/com/danrusu/pods4k/immutableArrays/TransformationsToMap.kt
@@ -216,7 +216,7 @@ public fun <T, K> ImmutableArray<T>.groupBy(keySelector: (element: T) -> K): Map
     val result = LinkedHashMap<K, Any>()
     for (element in this) {
         val key = keySelector(element)
-        val builder = result.getOrPut(key) { ImmutableArray.Builder<T>() } as
+        val builder = result.getOrPut(key) { ImmutableArray.Builder<T>(size) } as
             ImmutableArray.Builder<T>
         builder.add(element)
     }
@@ -232,7 +232,7 @@ public fun <K> ImmutableBooleanArray.groupBy(keySelector: (element: Boolean) -> 
     val result = LinkedHashMap<K, Any>()
     for (element in this) {
         val key = keySelector(element)
-        val builder = result.getOrPut(key) { ImmutableBooleanArray.Builder() } as
+        val builder = result.getOrPut(key) { ImmutableBooleanArray.Builder(size) } as
             ImmutableBooleanArray.Builder
         builder.add(element)
     }
@@ -248,7 +248,7 @@ public fun <K> ImmutableByteArray.groupBy(keySelector: (element: Byte) -> K): Ma
     val result = LinkedHashMap<K, Any>()
     for (element in this) {
         val key = keySelector(element)
-        val builder = result.getOrPut(key) { ImmutableByteArray.Builder() } as
+        val builder = result.getOrPut(key) { ImmutableByteArray.Builder(size) } as
             ImmutableByteArray.Builder
         builder.add(element)
     }
@@ -264,7 +264,7 @@ public fun <K> ImmutableCharArray.groupBy(keySelector: (element: Char) -> K): Ma
     val result = LinkedHashMap<K, Any>()
     for (element in this) {
         val key = keySelector(element)
-        val builder = result.getOrPut(key) { ImmutableCharArray.Builder() } as
+        val builder = result.getOrPut(key) { ImmutableCharArray.Builder(size) } as
             ImmutableCharArray.Builder
         builder.add(element)
     }
@@ -280,7 +280,7 @@ public fun <K> ImmutableShortArray.groupBy(keySelector: (element: Short) -> K): 
     val result = LinkedHashMap<K, Any>()
     for (element in this) {
         val key = keySelector(element)
-        val builder = result.getOrPut(key) { ImmutableShortArray.Builder() } as
+        val builder = result.getOrPut(key) { ImmutableShortArray.Builder(size) } as
             ImmutableShortArray.Builder
         builder.add(element)
     }
@@ -296,7 +296,7 @@ public fun <K> ImmutableIntArray.groupBy(keySelector: (element: Int) -> K): Map<
     val result = LinkedHashMap<K, Any>()
     for (element in this) {
         val key = keySelector(element)
-        val builder = result.getOrPut(key) { ImmutableIntArray.Builder() } as
+        val builder = result.getOrPut(key) { ImmutableIntArray.Builder(size) } as
             ImmutableIntArray.Builder
         builder.add(element)
     }
@@ -312,7 +312,7 @@ public fun <K> ImmutableLongArray.groupBy(keySelector: (element: Long) -> K): Ma
     val result = LinkedHashMap<K, Any>()
     for (element in this) {
         val key = keySelector(element)
-        val builder = result.getOrPut(key) { ImmutableLongArray.Builder() } as
+        val builder = result.getOrPut(key) { ImmutableLongArray.Builder(size) } as
             ImmutableLongArray.Builder
         builder.add(element)
     }
@@ -328,7 +328,7 @@ public fun <K> ImmutableFloatArray.groupBy(keySelector: (element: Float) -> K): 
     val result = LinkedHashMap<K, Any>()
     for (element in this) {
         val key = keySelector(element)
-        val builder = result.getOrPut(key) { ImmutableFloatArray.Builder() } as
+        val builder = result.getOrPut(key) { ImmutableFloatArray.Builder(size) } as
             ImmutableFloatArray.Builder
         builder.add(element)
     }
@@ -344,7 +344,7 @@ public fun <K> ImmutableDoubleArray.groupBy(keySelector: (element: Double) -> K)
     val result = LinkedHashMap<K, Any>()
     for (element in this) {
         val key = keySelector(element)
-        val builder = result.getOrPut(key) { ImmutableDoubleArray.Builder() } as
+        val builder = result.getOrPut(key) { ImmutableDoubleArray.Builder(size) } as
             ImmutableDoubleArray.Builder
         builder.add(element)
     }


### PR DESCRIPTION
Hi @daniel-rusu!

Great idea! While most Kotlin applications certainly don't need to worry about squeezing out the efficiency of using something like `ImmutableArray`, it is undoubtedly a valuable tool to add to the Kotlin ecosystem. Your implementation is great!

This PR changes the use of `Builder()` to `Builder(size)` based on the idea that some of these operations would typically result in arrays of around the same size as the original array, while other operations will never result in an array exceeding the size of the original array, and as such having an initial capacity of the same size means we can avoid repeatedly resizing the array of the builder. E.g. for something like `filter` and `mapNotNull` we know that the result is at most an array of the same size as the original array, so by having an initial capacity capable of holding all the elements, we will see _at most_ 2 array allocations.

- [X] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [X] Have you added tests that validate the new capability or bug fix?
- [X] Does your submission align with the current code style?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/daniel-rusu/pods4k/pulls) for the same change?

Looking forward to your feedback!