### PR TITLE
Concatenate Immutable Arrays without builders

### DIFF
--- a/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/ImmutableArrayExtensionsGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/ImmutableArrayExtensionsGenerator.kt
@@ -319,13 +319,18 @@ private fun FileSpec.Builder.addPlusImmutableArray() {
         ) {
             addGenericTypes(baseType.type)
 
-            controlFlow("when") {
-                statement("isEmpty() -> return other")
-                statement("other.isEmpty() -> return this")
-            }
-            controlFlow("return build${baseType.generatedClassName}(initialCapacity = size + other.size)") {
-                statement("addAll(this@plus)")
-                statement("addAll(other)")
+            controlFlow("return when") {
+                statement("isEmpty() -> other")
+                statement("other.isEmpty() -> this")
+                if (baseType == GENERIC) {
+                    suppress("UNCHECKED_CAST")
+                    statement(
+                        "else -> ${baseType.generatedClassName}((this.values as Array<%T>) + other.values)",
+                        baseType.type,
+                    )
+                } else {
+                    statement("else -> ${baseType.generatedClassName}(this.values + other.values)")
+                }
             }
         }
     }

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ _Date TBD_
 
 **Performance Improvements:**
 
+* Update `plus` to concatenate Immutable Arrays without using builders.
 * Update `sortedWith` on `ImmutableArray<T>` to copy the elements with `arraycopy`.
 * Update `partition` to use `arraycopy` to copy from the left side of the buffer.
 

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrays.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrays.kt
@@ -826,136 +826,95 @@ public fun ImmutableDoubleArray.sortedDescending(): ImmutableDoubleArray {
  * Leaves [this] immutable array as is and returns an [ImmutableArray] with the elements of [this]
  * followed by the elements of [other]
  */
-public operator fun <T> ImmutableArray<T>.plus(other: ImmutableArray<T>): ImmutableArray<T> {
-    when {
-        isEmpty() -> return other
-        other.isEmpty() -> return this
-    }
-    return buildImmutableArray(initialCapacity = size + other.size) {
-        addAll(this@plus)
-        addAll(other)
-    }
+@Suppress("UNCHECKED_CAST")
+public operator fun <T> ImmutableArray<T>.plus(other: ImmutableArray<T>): ImmutableArray<T> = when {
+    isEmpty() -> other
+    other.isEmpty() -> this
+    else -> ImmutableArray((this.values as Array<T>) + other.values)
 }
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableBooleanArray] with the elements of
  * [this] followed by the elements of [other]
  */
-public operator fun ImmutableBooleanArray.plus(other: ImmutableBooleanArray): ImmutableBooleanArray {
-    when {
-        isEmpty() -> return other
-        other.isEmpty() -> return this
-    }
-    return buildImmutableBooleanArray(initialCapacity = size + other.size) {
-        addAll(this@plus)
-        addAll(other)
-    }
+public operator fun ImmutableBooleanArray.plus(other: ImmutableBooleanArray): ImmutableBooleanArray = when {
+    isEmpty() -> other
+    other.isEmpty() -> this
+    else -> ImmutableBooleanArray(this.values + other.values)
 }
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableByteArray] with the elements of
  * [this] followed by the elements of [other]
  */
-public operator fun ImmutableByteArray.plus(other: ImmutableByteArray): ImmutableByteArray {
-    when {
-        isEmpty() -> return other
-        other.isEmpty() -> return this
-    }
-    return buildImmutableByteArray(initialCapacity = size + other.size) {
-        addAll(this@plus)
-        addAll(other)
-    }
+public operator fun ImmutableByteArray.plus(other: ImmutableByteArray): ImmutableByteArray = when {
+    isEmpty() -> other
+    other.isEmpty() -> this
+    else -> ImmutableByteArray(this.values + other.values)
 }
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableCharArray] with the elements of
  * [this] followed by the elements of [other]
  */
-public operator fun ImmutableCharArray.plus(other: ImmutableCharArray): ImmutableCharArray {
-    when {
-        isEmpty() -> return other
-        other.isEmpty() -> return this
-    }
-    return buildImmutableCharArray(initialCapacity = size + other.size) {
-        addAll(this@plus)
-        addAll(other)
-    }
+public operator fun ImmutableCharArray.plus(other: ImmutableCharArray): ImmutableCharArray = when {
+    isEmpty() -> other
+    other.isEmpty() -> this
+    else -> ImmutableCharArray(this.values + other.values)
 }
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableShortArray] with the elements of
  * [this] followed by the elements of [other]
  */
-public operator fun ImmutableShortArray.plus(other: ImmutableShortArray): ImmutableShortArray {
+public operator fun ImmutableShortArray.plus(other: ImmutableShortArray): ImmutableShortArray =
     when {
-        isEmpty() -> return other
-        other.isEmpty() -> return this
+        isEmpty() -> other
+        other.isEmpty() -> this
+        else -> ImmutableShortArray(this.values + other.values)
     }
-    return buildImmutableShortArray(initialCapacity = size + other.size) {
-        addAll(this@plus)
-        addAll(other)
-    }
-}
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableIntArray] with the elements of
  * [this] followed by the elements of [other]
  */
-public operator fun ImmutableIntArray.plus(other: ImmutableIntArray): ImmutableIntArray {
-    when {
-        isEmpty() -> return other
-        other.isEmpty() -> return this
-    }
-    return buildImmutableIntArray(initialCapacity = size + other.size) {
-        addAll(this@plus)
-        addAll(other)
-    }
+public operator fun ImmutableIntArray.plus(other: ImmutableIntArray): ImmutableIntArray = when {
+    isEmpty() -> other
+    other.isEmpty() -> this
+    else -> ImmutableIntArray(this.values + other.values)
 }
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableLongArray] with the elements of
  * [this] followed by the elements of [other]
  */
-public operator fun ImmutableLongArray.plus(other: ImmutableLongArray): ImmutableLongArray {
-    when {
-        isEmpty() -> return other
-        other.isEmpty() -> return this
-    }
-    return buildImmutableLongArray(initialCapacity = size + other.size) {
-        addAll(this@plus)
-        addAll(other)
-    }
+public operator fun ImmutableLongArray.plus(other: ImmutableLongArray): ImmutableLongArray = when {
+    isEmpty() -> other
+    other.isEmpty() -> this
+    else -> ImmutableLongArray(this.values + other.values)
 }
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableFloatArray] with the elements of
  * [this] followed by the elements of [other]
  */
-public operator fun ImmutableFloatArray.plus(other: ImmutableFloatArray): ImmutableFloatArray {
+public operator fun ImmutableFloatArray.plus(other: ImmutableFloatArray): ImmutableFloatArray =
     when {
-        isEmpty() -> return other
-        other.isEmpty() -> return this
+        isEmpty() -> other
+        other.isEmpty() -> this
+        else -> ImmutableFloatArray(this.values + other.values)
     }
-    return buildImmutableFloatArray(initialCapacity = size + other.size) {
-        addAll(this@plus)
-        addAll(other)
-    }
-}
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableDoubleArray] with the elements of
  * [this] followed by the elements of [other]
  */
-public operator fun ImmutableDoubleArray.plus(other: ImmutableDoubleArray): ImmutableDoubleArray {
+public operator fun ImmutableDoubleArray.plus(other: ImmutableDoubleArray): ImmutableDoubleArray =
     when {
-        isEmpty() -> return other
-        other.isEmpty() -> return this
+        isEmpty() -> other
+        other.isEmpty() -> this
+        else -> ImmutableDoubleArray(this.values + other.values)
     }
-    return buildImmutableDoubleArray(initialCapacity = size + other.size) {
-        addAll(this@plus)
-        addAll(other)
-    }
-}
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableArray] with the elements of [this]


### PR DESCRIPTION
Tiny efficiency improvement to avoid using builders when concatenating Immutable Arrays.

Resolves the first part of https://github.com/daniel-rusu/pods4k/issues/7
