### PR TITLE
Concatenate element without builder

### DIFF
--- a/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/ImmutableArrayExtensionsGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/ImmutableArrayExtensionsGenerator.kt
@@ -350,12 +350,15 @@ private fun FileSpec.Builder.addPlusValue() {
             name = "plus",
             parameters = { "element"(type = baseType.type) },
             returns = baseType.getGeneratedTypeName(),
+            forceFunctionBody = true,
         ) {
             addGenericTypes(baseType.type)
 
-            controlFlow("return build${baseType.generatedClassName}(initialCapacity = size + 1)") {
-                statement("addAll(this@plus)")
-                statement("add(element)")
+            if (baseType == GENERIC) {
+                suppress("UNCHECKED_CAST")
+                statement("return ${baseType.generatedClassName}((values as Array<%T>) + element)", baseType.type)
+            } else {
+                statement("return ${baseType.generatedClassName}(values + element)")
             }
         }
     }

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,8 @@ _Date TBD_
 
 **Performance Improvements:**
 
-* Update `plus` to concatenate Immutable Arrays without using builders.
+* Update `plus` to concatenate an element with an Immutable Array without using builders.
+* Update `plus` to concatenate 2 Immutable Arrays without using builders.
 * Update `sortedWith` on `ImmutableArray<T>` to copy the elements with `arraycopy`.
 * Update `partition` to use `arraycopy` to copy from the left side of the buffer.
 

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrays.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrays.kt
@@ -924,11 +924,10 @@ public operator fun ImmutableDoubleArray.plus(other: ImmutableDoubleArray): Immu
  * When needing to add multiple elements individually, use the buildImmutableArray methods or
  * immutable array builders as that's much more efficient instead of calling this function repeatedly.
  */
-public operator fun <T> ImmutableArray<T>.plus(element: T): ImmutableArray<T> =
-    buildImmutableArray(initialCapacity = size + 1) {
-        addAll(this@plus)
-        add(element)
-    }
+@Suppress("UNCHECKED_CAST")
+public operator fun <T> ImmutableArray<T>.plus(element: T): ImmutableArray<T> {
+    return ImmutableArray((values as Array<T>) + element)
+}
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableBooleanArray] with the elements of
@@ -938,11 +937,9 @@ public operator fun <T> ImmutableArray<T>.plus(element: T): ImmutableArray<T> =
  * When needing to add multiple elements individually, use the buildImmutableArray methods or
  * immutable array builders as that's much more efficient instead of calling this function repeatedly.
  */
-public operator fun ImmutableBooleanArray.plus(element: Boolean): ImmutableBooleanArray =
-    buildImmutableBooleanArray(initialCapacity = size + 1) {
-        addAll(this@plus)
-        add(element)
-    }
+public operator fun ImmutableBooleanArray.plus(element: Boolean): ImmutableBooleanArray {
+    return ImmutableBooleanArray(values + element)
+}
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableByteArray] with the elements of
@@ -952,11 +949,9 @@ public operator fun ImmutableBooleanArray.plus(element: Boolean): ImmutableBoole
  * When needing to add multiple elements individually, use the buildImmutableArray methods or
  * immutable array builders as that's much more efficient instead of calling this function repeatedly.
  */
-public operator fun ImmutableByteArray.plus(element: Byte): ImmutableByteArray =
-    buildImmutableByteArray(initialCapacity = size + 1) {
-        addAll(this@plus)
-        add(element)
-    }
+public operator fun ImmutableByteArray.plus(element: Byte): ImmutableByteArray {
+    return ImmutableByteArray(values + element)
+}
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableCharArray] with the elements of
@@ -966,11 +961,9 @@ public operator fun ImmutableByteArray.plus(element: Byte): ImmutableByteArray =
  * When needing to add multiple elements individually, use the buildImmutableArray methods or
  * immutable array builders as that's much more efficient instead of calling this function repeatedly.
  */
-public operator fun ImmutableCharArray.plus(element: Char): ImmutableCharArray =
-    buildImmutableCharArray(initialCapacity = size + 1) {
-        addAll(this@plus)
-        add(element)
-    }
+public operator fun ImmutableCharArray.plus(element: Char): ImmutableCharArray {
+    return ImmutableCharArray(values + element)
+}
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableShortArray] with the elements of
@@ -980,11 +973,9 @@ public operator fun ImmutableCharArray.plus(element: Char): ImmutableCharArray =
  * When needing to add multiple elements individually, use the buildImmutableArray methods or
  * immutable array builders as that's much more efficient instead of calling this function repeatedly.
  */
-public operator fun ImmutableShortArray.plus(element: Short): ImmutableShortArray =
-    buildImmutableShortArray(initialCapacity = size + 1) {
-        addAll(this@plus)
-        add(element)
-    }
+public operator fun ImmutableShortArray.plus(element: Short): ImmutableShortArray {
+    return ImmutableShortArray(values + element)
+}
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableIntArray] with the elements of
@@ -994,11 +985,9 @@ public operator fun ImmutableShortArray.plus(element: Short): ImmutableShortArra
  * When needing to add multiple elements individually, use the buildImmutableArray methods or
  * immutable array builders as that's much more efficient instead of calling this function repeatedly.
  */
-public operator fun ImmutableIntArray.plus(element: Int): ImmutableIntArray =
-    buildImmutableIntArray(initialCapacity = size + 1) {
-        addAll(this@plus)
-        add(element)
-    }
+public operator fun ImmutableIntArray.plus(element: Int): ImmutableIntArray {
+    return ImmutableIntArray(values + element)
+}
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableLongArray] with the elements of
@@ -1008,11 +997,9 @@ public operator fun ImmutableIntArray.plus(element: Int): ImmutableIntArray =
  * When needing to add multiple elements individually, use the buildImmutableArray methods or
  * immutable array builders as that's much more efficient instead of calling this function repeatedly.
  */
-public operator fun ImmutableLongArray.plus(element: Long): ImmutableLongArray =
-    buildImmutableLongArray(initialCapacity = size + 1) {
-        addAll(this@plus)
-        add(element)
-    }
+public operator fun ImmutableLongArray.plus(element: Long): ImmutableLongArray {
+    return ImmutableLongArray(values + element)
+}
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableFloatArray] with the elements of
@@ -1022,11 +1009,9 @@ public operator fun ImmutableLongArray.plus(element: Long): ImmutableLongArray =
  * When needing to add multiple elements individually, use the buildImmutableArray methods or
  * immutable array builders as that's much more efficient instead of calling this function repeatedly.
  */
-public operator fun ImmutableFloatArray.plus(element: Float): ImmutableFloatArray =
-    buildImmutableFloatArray(initialCapacity = size + 1) {
-        addAll(this@plus)
-        add(element)
-    }
+public operator fun ImmutableFloatArray.plus(element: Float): ImmutableFloatArray {
+    return ImmutableFloatArray(values + element)
+}
 
 /**
  * Leaves [this] immutable array as is and returns an [ImmutableDoubleArray] with the elements of
@@ -1036,11 +1021,9 @@ public operator fun ImmutableFloatArray.plus(element: Float): ImmutableFloatArra
  * When needing to add multiple elements individually, use the buildImmutableArray methods or
  * immutable array builders as that's much more efficient instead of calling this function repeatedly.
  */
-public operator fun ImmutableDoubleArray.plus(element: Double): ImmutableDoubleArray =
-    buildImmutableDoubleArray(initialCapacity = size + 1) {
-        addAll(this@plus)
-        add(element)
-    }
+public operator fun ImmutableDoubleArray.plus(element: Double): ImmutableDoubleArray {
+    return ImmutableDoubleArray(values + element)
+}
 
 /**
  * Returns an [ImmutableBooleanArray] containing the unboxed values of this array.


### PR DESCRIPTION
Avoid creating a builder when concatenating an element.  The relative efficiency improvement is felt more when working with small Immutable Arrays.

Addresses the second part of https://github.com/daniel-rusu/pods4k/issues/7