### PR TITLE
Add toTypedMutableArray extension functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ _Date TBD_
 
 **New Features:**
 
+* Add `toTypedMutableArray()` extension functions
 * Add `referencesSameArrayAs(immutableArray)` method since referential equality isn't allowed for inline classes
 * Add `copyFrom(regularArray, startIndex, size)` companion factory function
 * Add `randomOrNull(Random)` method

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrays.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrays.kt
@@ -5,6 +5,7 @@ import java.lang.IllegalArgumentException
 import java.util.Arrays
 import java.util.RandomAccess
 import kotlin.Any
+import kotlin.Array
 import kotlin.Boolean
 import kotlin.Byte
 import kotlin.Char
@@ -1177,6 +1178,53 @@ public fun ImmutableFloatArray.toTypedImmutableArray(): ImmutableArray<Float> {
 public fun ImmutableDoubleArray.toTypedImmutableArray(): ImmutableArray<Double> {
     return ImmutableArray(size) { this[it] }
 }
+
+/**
+ * Returns a regular (mutable) typed array with a copy of the elements.
+ */
+public inline fun <reified T> ImmutableArray<T>.toTypedMutableArray(): Array<out T> = Array(size) {
+    values[it]
+}
+
+/**
+ * Returns a regular (mutable) typed array with a copy of the elements.
+ */
+public fun ImmutableBooleanArray.toTypedMutableArray(): Array<Boolean> = Array(size) { values[it] }
+
+/**
+ * Returns a regular (mutable) typed array with a copy of the elements.
+ */
+public fun ImmutableByteArray.toTypedMutableArray(): Array<Byte> = Array(size) { values[it] }
+
+/**
+ * Returns a regular (mutable) typed array with a copy of the elements.
+ */
+public fun ImmutableCharArray.toTypedMutableArray(): Array<Char> = Array(size) { values[it] }
+
+/**
+ * Returns a regular (mutable) typed array with a copy of the elements.
+ */
+public fun ImmutableShortArray.toTypedMutableArray(): Array<Short> = Array(size) { values[it] }
+
+/**
+ * Returns a regular (mutable) typed array with a copy of the elements.
+ */
+public fun ImmutableIntArray.toTypedMutableArray(): Array<Int> = Array(size) { values[it] }
+
+/**
+ * Returns a regular (mutable) typed array with a copy of the elements.
+ */
+public fun ImmutableLongArray.toTypedMutableArray(): Array<Long> = Array(size) { values[it] }
+
+/**
+ * Returns a regular (mutable) typed array with a copy of the elements.
+ */
+public fun ImmutableFloatArray.toTypedMutableArray(): Array<Float> = Array(size) { values[it] }
+
+/**
+ * Returns a regular (mutable) typed array with a copy of the elements.
+ */
+public fun ImmutableDoubleArray.toTypedMutableArray(): Array<Double> = Array(size) { values[it] }
 
 /**
  * Ensures that none of the elements are null otherwise an [IllegalArgumentException] is thrown.

--- a/immutable-arrays/core/src/test/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrayTest.kt
+++ b/immutable-arrays/core/src/test/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrayTest.kt
@@ -518,6 +518,41 @@ class ImmutableArrayTest {
     }
 
     @Test
+    fun `toTypedMutableArray validation`() {
+        with(emptyImmutableArray<String>()) {
+            val result = toTypedMutableArray()
+
+            expectThat(result)
+                .isA<Array<String>>()
+
+            expectThat(result.size)
+                .isEqualTo(0)
+        }
+
+        with(immutableArrayOf("a", "b", "c")) {
+            expectThat(toTypedMutableArray())
+                .isEqualTo(arrayOf("a", "b", "c"))
+        }
+    }
+
+    @Test
+    fun `can use spread operator with toTypedMutableArray`() {
+        fun inspectNames(vararg names: String) {
+            expectThat(names.size)
+                .isEqualTo(2)
+
+            expectThat(names[0])
+                .isEqualTo("Dan")
+
+            expectThat(names[1])
+                .isEqualTo("Jill")
+        }
+
+        val names = immutableArrayOf("Dan", "Jill")
+        inspectNames(*names.toTypedMutableArray())
+    }
+
+    @Test
     fun `forEach validation`() {
         with(immutableArrayOf("one", "two", "three")) {
             val elements = mutableListOf<String>()

--- a/immutable-arrays/core/src/test/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableIntArrayTest.kt
+++ b/immutable-arrays/core/src/test/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableIntArrayTest.kt
@@ -533,6 +533,42 @@ class ImmutableIntArrayTest {
     }
 
     @Test
+    fun `toTypedMutableArray validation`() {
+        with(emptyImmutableIntArray()) {
+            val result = toTypedMutableArray()
+
+            expectThat(result)
+                .isA<Array<Int>>()
+
+            expectThat(result.size)
+                .isEqualTo(0)
+        }
+
+        with(immutableArrayOf(1, 2, 3)) {
+            expectThat(toTypedMutableArray())
+                .isEqualTo(arrayOf(1, 2, 3))
+        }
+    }
+
+    @Test
+    fun `can use spread operator with toTypedMutableArray`() {
+        // Note that numbers is Int? instead of Int otherwise a primitive non-typed array would be required
+        fun inspectNumbers(vararg numbers: Int?) {
+            expectThat(numbers.size)
+                .isEqualTo(2)
+
+            expectThat(numbers[0])
+                .isEqualTo(100)
+
+            expectThat(numbers[1])
+                .isEqualTo(200)
+        }
+
+        val numbers = immutableArrayOf(100, 200)
+        inspectNumbers(*numbers.toTypedMutableArray())
+    }
+
+    @Test
     fun `forEach validation`() {
         with(immutableArrayOf(1, 2, 3)) {
             val elements = mutableListOf<Int>()


### PR DESCRIPTION
Resolves the first part of https://github.com/daniel-rusu/pods4k/issues/11 to allow passing immutable array values to functions that accept non-primitive vararg parameters.

Example usage:

```kotlin
val names = immutableArrayOf("Dan", "Jill")
logNames(*names.toTypedMutableArray())

fun logNames(vararg names: String) {
    //...
}
```