### PR TITLE
Add toMutableArray extension functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ _Date TBD_
 
 **New Features:**
 
+* Add `toMutableArray()` extension functions
 * Add `toTypedMutableArray()` extension functions
 * Add `referencesSameArrayAs(immutableArray)` method since referential equality isn't allowed for inline classes
 * Add `copyFrom(regularArray, startIndex, size)` companion factory function

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrays.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrays.kt
@@ -7,14 +7,22 @@ import java.util.RandomAccess
 import kotlin.Any
 import kotlin.Array
 import kotlin.Boolean
+import kotlin.BooleanArray
 import kotlin.Byte
+import kotlin.ByteArray
 import kotlin.Char
+import kotlin.CharArray
 import kotlin.Comparable
 import kotlin.Double
+import kotlin.DoubleArray
 import kotlin.Float
+import kotlin.FloatArray
 import kotlin.Int
+import kotlin.IntArray
 import kotlin.Long
+import kotlin.LongArray
 import kotlin.Short
+import kotlin.ShortArray
 import kotlin.Suppress
 import kotlin.collections.AbstractList
 import kotlin.collections.Iterable
@@ -1178,6 +1186,53 @@ public fun ImmutableFloatArray.toTypedImmutableArray(): ImmutableArray<Float> {
 public fun ImmutableDoubleArray.toTypedImmutableArray(): ImmutableArray<Double> {
     return ImmutableArray(size) { this[it] }
 }
+
+/**
+ * Returns a regular (mutable) array with a copy of the elements.
+ */
+public inline fun <reified T> ImmutableArray<T>.toMutableArray(): Array<out T> = Array(size) {
+    values[it]
+}
+
+/**
+ * Returns a regular (mutable) array with a copy of the elements.
+ */
+public fun ImmutableBooleanArray.toMutableArray(): BooleanArray = values.copyOf()
+
+/**
+ * Returns a regular (mutable) array with a copy of the elements.
+ */
+public fun ImmutableByteArray.toMutableArray(): ByteArray = values.copyOf()
+
+/**
+ * Returns a regular (mutable) array with a copy of the elements.
+ */
+public fun ImmutableCharArray.toMutableArray(): CharArray = values.copyOf()
+
+/**
+ * Returns a regular (mutable) array with a copy of the elements.
+ */
+public fun ImmutableShortArray.toMutableArray(): ShortArray = values.copyOf()
+
+/**
+ * Returns a regular (mutable) array with a copy of the elements.
+ */
+public fun ImmutableIntArray.toMutableArray(): IntArray = values.copyOf()
+
+/**
+ * Returns a regular (mutable) array with a copy of the elements.
+ */
+public fun ImmutableLongArray.toMutableArray(): LongArray = values.copyOf()
+
+/**
+ * Returns a regular (mutable) array with a copy of the elements.
+ */
+public fun ImmutableFloatArray.toMutableArray(): FloatArray = values.copyOf()
+
+/**
+ * Returns a regular (mutable) array with a copy of the elements.
+ */
+public fun ImmutableDoubleArray.toMutableArray(): DoubleArray = values.copyOf()
 
 /**
  * Returns a regular (mutable) typed array with a copy of the elements.

--- a/immutable-arrays/core/src/test/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrayTest.kt
+++ b/immutable-arrays/core/src/test/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrayTest.kt
@@ -518,6 +518,24 @@ class ImmutableArrayTest {
     }
 
     @Test
+    fun `toMutableArray validation`() {
+        with(emptyImmutableArray<String>()) {
+            val result = toMutableArray()
+
+            expectThat(result)
+                .isA<Array<String>>()
+
+            expectThat(result.size)
+                .isEqualTo(0)
+        }
+
+        with(immutableArrayOf("a", "b", "c")) {
+            expectThat(toMutableArray())
+                .isEqualTo(arrayOf("a", "b", "c"))
+        }
+    }
+
+    @Test
     fun `toTypedMutableArray validation`() {
         with(emptyImmutableArray<String>()) {
             val result = toTypedMutableArray()
@@ -536,7 +554,7 @@ class ImmutableArrayTest {
     }
 
     @Test
-    fun `can use spread operator with toTypedMutableArray`() {
+    fun `can use spread operator with toMutableArray and toTypedMutableArray`() {
         fun inspectNames(vararg names: String) {
             expectThat(names.size)
                 .isEqualTo(2)
@@ -549,6 +567,7 @@ class ImmutableArrayTest {
         }
 
         val names = immutableArrayOf("Dan", "Jill")
+        inspectNames(*names.toMutableArray())
         inspectNames(*names.toTypedMutableArray())
     }
 

--- a/immutable-arrays/core/src/test/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableIntArrayTest.kt
+++ b/immutable-arrays/core/src/test/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableIntArrayTest.kt
@@ -533,6 +533,24 @@ class ImmutableIntArrayTest {
     }
 
     @Test
+    fun `toMutableArray validation`() {
+        with(emptyImmutableIntArray()) {
+            val result = toMutableArray()
+
+            expectThat(result)
+                .isA<IntArray>()
+
+            expectThat(result.size)
+                .isEqualTo(0)
+        }
+
+        with(immutableArrayOf(1, 2, 3)) {
+            expectThat(toMutableArray())
+                .isEqualTo(intArrayOf(1, 2, 3))
+        }
+    }
+
+    @Test
     fun `toTypedMutableArray validation`() {
         with(emptyImmutableIntArray()) {
             val result = toTypedMutableArray()
@@ -566,6 +584,23 @@ class ImmutableIntArrayTest {
 
         val numbers = immutableArrayOf(100, 200)
         inspectNumbers(*numbers.toTypedMutableArray())
+    }
+
+    @Test
+    fun `can use spread operator with toMutableArray`() {
+        fun inspectNumbers(vararg numbers: Int) {
+            expectThat(numbers.size)
+                .isEqualTo(2)
+
+            expectThat(numbers[0])
+                .isEqualTo(100)
+
+            expectThat(numbers[1])
+                .isEqualTo(200)
+        }
+
+        val numbers = immutableArrayOf(100, 200)
+        inspectNumbers(*numbers.toMutableArray())
     }
 
     @Test


### PR DESCRIPTION
This resolves the second part of https://github.com/daniel-rusu/pods4k/issues/11 to allow passing immutable array values to functions that accept primitive vararg parameters.

Example usage:

```kotlin
val numbers = immutableArrayOf(1, 2, 3)
logNumbers(*names.toMutableArray())

fun logNumbers(vararg numbers: Int) {
    //...
}
```