### PR TITLE
KMP Preparation - Replace Java Comparator with Kotlin version

### DIFF
--- a/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/ImmutableArrayGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/danrusu/pods4k/immutableArrays/core/ImmutableArrayGenerator.kt
@@ -941,7 +941,7 @@ private fun TypeSpec.Builder.addSortedWith(baseType: BaseType) {
         name = "sortedWith",
         parameters = {
             "comparator"(
-                type = Comparator::class.asTypeName().parameterizedBy(WildcardTypeName.consumerOf(baseType.type)),
+                type = ClassName("kotlin", "Comparator").parameterizedBy(WildcardTypeName.consumerOf(baseType.type)),
             )
         },
         returns = baseType.getGeneratedTypeName(),
@@ -953,13 +953,13 @@ private fun TypeSpec.Builder.addSortedWith(baseType: BaseType) {
             statement("val backingArray = arrayOfNulls<Any?>(size) as Array<%T>", baseType.type)
             statement("System.arraycopy(values, 0, backingArray, 0, size)")
             emptyLine()
-            statement("%T.sort(backingArray, comparator)", java.util.Arrays::class)
+            statement("backingArray.sortWith(comparator)")
             statement("return ${baseType.generatedClassName}(backingArray)")
         } else {
             // The standard library comparator-based sort utilities only operate on generic arrays.
             // This is probably to avoid auto-boxing each value everytime it's compared
             statement("val temp = values.toTypedArray()")
-            statement("%T.sort(temp, comparator)", java.util.Arrays::class)
+            statement("temp.sortWith(comparator)")
             statement("return temp.toImmutableArray()")
         }
     }

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArray.kt
@@ -1,13 +1,12 @@
 // Auto-generated file. DO NOT EDIT!
 package com.danrusu.pods4k.immutableArrays
 
-import java.util.Arrays
-import java.util.Comparator
 import kotlin.Any
 import kotlin.Array
 import kotlin.Boolean
 import kotlin.CharSequence
 import kotlin.Comparable
+import kotlin.Comparator
 import kotlin.Double
 import kotlin.Float
 import kotlin.Int
@@ -550,7 +549,7 @@ public value class ImmutableArray<out T> @PublishedApi internal constructor(
         val backingArray = arrayOfNulls<Any?>(size) as Array<T>
         System.arraycopy(values, 0, backingArray, 0, size)
 
-        Arrays.sort(backingArray, comparator)
+        backingArray.sortWith(comparator)
         return ImmutableArray(backingArray)
     }
 

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableBooleanArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableBooleanArray.kt
@@ -1,13 +1,12 @@
 // Auto-generated file. DO NOT EDIT!
 package com.danrusu.pods4k.immutableArrays
 
-import java.util.Arrays
-import java.util.Comparator
 import kotlin.Array
 import kotlin.Boolean
 import kotlin.BooleanArray
 import kotlin.CharSequence
 import kotlin.Comparable
+import kotlin.Comparator
 import kotlin.Double
 import kotlin.Float
 import kotlin.Int
@@ -545,7 +544,7 @@ public value class ImmutableBooleanArray @PublishedApi internal constructor(
         if (size <= 1) return this
 
         val temp = values.toTypedArray()
-        Arrays.sort(temp, comparator)
+        temp.sortWith(comparator)
         return temp.toImmutableArray()
     }
 

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableByteArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableByteArray.kt
@@ -1,14 +1,13 @@
 // Auto-generated file. DO NOT EDIT!
 package com.danrusu.pods4k.immutableArrays
 
-import java.util.Arrays
-import java.util.Comparator
 import kotlin.Array
 import kotlin.Boolean
 import kotlin.Byte
 import kotlin.ByteArray
 import kotlin.CharSequence
 import kotlin.Comparable
+import kotlin.Comparator
 import kotlin.Double
 import kotlin.Float
 import kotlin.Int
@@ -546,7 +545,7 @@ public value class ImmutableByteArray @PublishedApi internal constructor(
         if (size <= 1) return this
 
         val temp = values.toTypedArray()
-        Arrays.sort(temp, comparator)
+        temp.sortWith(comparator)
         return temp.toImmutableArray()
     }
 

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableCharArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableCharArray.kt
@@ -1,14 +1,13 @@
 // Auto-generated file. DO NOT EDIT!
 package com.danrusu.pods4k.immutableArrays
 
-import java.util.Arrays
-import java.util.Comparator
 import kotlin.Array
 import kotlin.Boolean
 import kotlin.Char
 import kotlin.CharArray
 import kotlin.CharSequence
 import kotlin.Comparable
+import kotlin.Comparator
 import kotlin.Double
 import kotlin.Float
 import kotlin.Int
@@ -546,7 +545,7 @@ public value class ImmutableCharArray @PublishedApi internal constructor(
         if (size <= 1) return this
 
         val temp = values.toTypedArray()
-        Arrays.sort(temp, comparator)
+        temp.sortWith(comparator)
         return temp.toImmutableArray()
     }
 

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableDoubleArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableDoubleArray.kt
@@ -1,12 +1,11 @@
 // Auto-generated file. DO NOT EDIT!
 package com.danrusu.pods4k.immutableArrays
 
-import java.util.Arrays
-import java.util.Comparator
 import kotlin.Array
 import kotlin.Boolean
 import kotlin.CharSequence
 import kotlin.Comparable
+import kotlin.Comparator
 import kotlin.Double
 import kotlin.DoubleArray
 import kotlin.Float
@@ -545,7 +544,7 @@ public value class ImmutableDoubleArray @PublishedApi internal constructor(
         if (size <= 1) return this
 
         val temp = values.toTypedArray()
-        Arrays.sort(temp, comparator)
+        temp.sortWith(comparator)
         return temp.toImmutableArray()
     }
 

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableFloatArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableFloatArray.kt
@@ -1,12 +1,11 @@
 // Auto-generated file. DO NOT EDIT!
 package com.danrusu.pods4k.immutableArrays
 
-import java.util.Arrays
-import java.util.Comparator
 import kotlin.Array
 import kotlin.Boolean
 import kotlin.CharSequence
 import kotlin.Comparable
+import kotlin.Comparator
 import kotlin.Double
 import kotlin.Float
 import kotlin.FloatArray
@@ -545,7 +544,7 @@ public value class ImmutableFloatArray @PublishedApi internal constructor(
         if (size <= 1) return this
 
         val temp = values.toTypedArray()
-        Arrays.sort(temp, comparator)
+        temp.sortWith(comparator)
         return temp.toImmutableArray()
     }
 

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableIntArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableIntArray.kt
@@ -1,12 +1,11 @@
 // Auto-generated file. DO NOT EDIT!
 package com.danrusu.pods4k.immutableArrays
 
-import java.util.Arrays
-import java.util.Comparator
 import kotlin.Array
 import kotlin.Boolean
 import kotlin.CharSequence
 import kotlin.Comparable
+import kotlin.Comparator
 import kotlin.Double
 import kotlin.Float
 import kotlin.Int
@@ -545,7 +544,7 @@ public value class ImmutableIntArray @PublishedApi internal constructor(
         if (size <= 1) return this
 
         val temp = values.toTypedArray()
-        Arrays.sort(temp, comparator)
+        temp.sortWith(comparator)
         return temp.toImmutableArray()
     }
 

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableLongArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableLongArray.kt
@@ -1,12 +1,11 @@
 // Auto-generated file. DO NOT EDIT!
 package com.danrusu.pods4k.immutableArrays
 
-import java.util.Arrays
-import java.util.Comparator
 import kotlin.Array
 import kotlin.Boolean
 import kotlin.CharSequence
 import kotlin.Comparable
+import kotlin.Comparator
 import kotlin.Double
 import kotlin.Float
 import kotlin.Int
@@ -545,7 +544,7 @@ public value class ImmutableLongArray @PublishedApi internal constructor(
         if (size <= 1) return this
 
         val temp = values.toTypedArray()
-        Arrays.sort(temp, comparator)
+        temp.sortWith(comparator)
         return temp.toImmutableArray()
     }
 

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableShortArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableShortArray.kt
@@ -1,12 +1,11 @@
 // Auto-generated file. DO NOT EDIT!
 package com.danrusu.pods4k.immutableArrays
 
-import java.util.Arrays
-import java.util.Comparator
 import kotlin.Array
 import kotlin.Boolean
 import kotlin.CharSequence
 import kotlin.Comparable
+import kotlin.Comparator
 import kotlin.Double
 import kotlin.Float
 import kotlin.Int
@@ -546,7 +545,7 @@ public value class ImmutableShortArray @PublishedApi internal constructor(
         if (size <= 1) return this
 
         val temp = values.toTypedArray()
-        Arrays.sort(temp, comparator)
+        temp.sortWith(comparator)
         return temp.toImmutableArray()
     }
 


### PR DESCRIPTION
Preparation towards supporting Kotlin Multiplatform https://github.com/daniel-rusu/pods4k/issues/5 by reducing JVM dependencies.

Replaced java.util.Comparator with kotlin.Comparator
