### PR TITLE
Reduce memory consumption and improve performance of filter, filterIndexed, and filterNot

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,9 @@ _Date TBD_
 
 **Performance Improvements:**
 
+* Update `filter`, `filterIndexed`, & `filterNot` to switch from accumulating elements in a builder to capturing
+  accepted elements as single bits in an `IntArray` and use bitwise operations to avoid branching. This cuts temporary
+  memory by over 10X and dramatically improves performance.
 * Update `distinct()` to use `filter` with a `HashSet` instead of calling `toSet().toImmutableArray()` to avoid using
   the more expensive `LinkedHashSet` while still maintaining original ordering. This also returns the same instance when
   all elements are already distinct.

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArray.kt
@@ -448,46 +448,82 @@ public value class ImmutableArray<out T> @PublishedApi internal constructor(
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
-    public inline fun filter(predicate: (element: T) -> Boolean): ImmutableArray<T> {
-        val result = Builder<T>()
-        for (element in values) {
-            if (predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filter(crossinline predicate: (element: T) -> Boolean): ImmutableArray<T> {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> predicate(element) }
     }
 
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
+     *
+     * Warning: This code is quite dense because it's highly optimized to reduce the temporary
+     * memory overhead and also dramatically improves performance due to branch elimination and
+     * a perfectly-sized result.
      */
-    public inline fun filterIndexed(predicate: (index: Int, element: T) -> Boolean): ImmutableArray<T> {
-        val result = Builder<T>()
-        forEachIndexed { index, element ->
-            if (predicate(index, element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
+    @Suppress("UNCHECKED_CAST")
+    public fun filterIndexed(predicate: (index: Int, element: T) -> Boolean): ImmutableArray<T> {
+        if (isEmpty()) return this
 
-        return result.build()
+        // divide by 32 rounding up
+        val bitArraySize = (size + 31) ushr 5
+        // store an array of int values whose 1-bits capture which elements pass the predicate
+        val bitArray = IntArray(bitArraySize)
+
+        var resultSize = 0
+        // the bit index into the current 32-bit int
+        var bitIndex = -1 // start at -1 as it gets incremented right away in the loop
+        var bitArrayIndex = 0
+        var currentBits = 0 // the current 32-bits with no elements yet
+        forEachIndexed { index, element ->
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so store them and reset
+                bitArray[bitArrayIndex++] = currentBits
+                currentBits = 0
+                bitIndex = 0
+            }
+            // jit turns this into a branchless operation
+            val currentElement = if (predicate(index, element)) 1 else 0
+
+            // conditionally increase the size without branching
+            resultSize += currentElement
+
+            // conditionally include the current element without branching
+            currentBits = currentBits or (currentElement shl bitIndex)
+        }
+        if (resultSize == 0) return EMPTY
+        if (resultSize == size) return this
+
+        // store the last set of partially-filled bits
+        bitArray[bitArrayIndex] = currentBits
+
+        val result = arrayOfNulls<Any>(resultSize) as Array<T>
+        var resultIndex = 0
+        bitArrayIndex = 0
+        bitIndex = -1
+        currentBits = bitArray[0]
+        var originalIndex = 0
+        // check the resultIndex instead of the originalIndex so that we can stop early
+        while (resultIndex < result.size) {
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so get the next 32 bits and reset
+                currentBits = bitArray[++bitArrayIndex]
+                bitIndex = 0
+            }
+            // always copy to avoid branching as resultIndex won't increment if current element isn't included
+            result[resultIndex] = this[originalIndex++]
+            // increment the resultIndex if the current element should be included
+            val currentElement = (currentBits ushr bitIndex) and 1
+            resultIndex += currentElement
+        }
+        return ImmutableArray(result)
     }
 
     /**
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
-    public inline fun filterNot(predicate: (element: T) -> Boolean): ImmutableArray<T> {
-        val result = Builder<T>()
-        for (element in values) {
-            if (!predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filterNot(crossinline predicate: (element: T) -> Boolean): ImmutableArray<T> {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> !predicate(element) }
     }
 
     /**
@@ -595,7 +631,7 @@ public value class ImmutableArray<out T> @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements having distinct keys returned by the
      * [selector]
      */
-    public inline fun <K> distinctBy(selector: (element: T) -> K): ImmutableArray<T> {
+    public inline fun <K> distinctBy(crossinline selector: (element: T) -> K): ImmutableArray<T> {
         if (size <= 1) return this
 
         val keys = HashSet<K>()

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableByteArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableByteArray.kt
@@ -448,46 +448,81 @@ public value class ImmutableByteArray @PublishedApi internal constructor(
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
-    public inline fun filter(predicate: (element: Byte) -> Boolean): ImmutableByteArray {
-        val result = Builder()
-        for (element in values) {
-            if (predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filter(crossinline predicate: (element: Byte) -> Boolean): ImmutableByteArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> predicate(element) }
     }
 
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
+     *
+     * Warning: This code is quite dense because it's highly optimized to reduce the temporary
+     * memory overhead and also dramatically improves performance due to branch elimination and
+     * a perfectly-sized result.
      */
-    public inline fun filterIndexed(predicate: (index: Int, element: Byte) -> Boolean): ImmutableByteArray {
-        val result = Builder()
-        forEachIndexed { index, element ->
-            if (predicate(index, element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
+    public fun filterIndexed(predicate: (index: Int, element: Byte) -> Boolean): ImmutableByteArray {
+        if (isEmpty()) return this
 
-        return result.build()
+        // divide by 32 rounding up
+        val bitArraySize = (size + 31) ushr 5
+        // store an array of int values whose 1-bits capture which elements pass the predicate
+        val bitArray = IntArray(bitArraySize)
+
+        var resultSize = 0
+        // the bit index into the current 32-bit int
+        var bitIndex = -1 // start at -1 as it gets incremented right away in the loop
+        var bitArrayIndex = 0
+        var currentBits = 0 // the current 32-bits with no elements yet
+        forEachIndexed { index, element ->
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so store them and reset
+                bitArray[bitArrayIndex++] = currentBits
+                currentBits = 0
+                bitIndex = 0
+            }
+            // jit turns this into a branchless operation
+            val currentElement = if (predicate(index, element)) 1 else 0
+
+            // conditionally increase the size without branching
+            resultSize += currentElement
+
+            // conditionally include the current element without branching
+            currentBits = currentBits or (currentElement shl bitIndex)
+        }
+        if (resultSize == 0) return EMPTY
+        if (resultSize == size) return this
+
+        // store the last set of partially-filled bits
+        bitArray[bitArrayIndex] = currentBits
+
+        val result = ByteArray(resultSize)
+        var resultIndex = 0
+        bitArrayIndex = 0
+        bitIndex = -1
+        currentBits = bitArray[0]
+        var originalIndex = 0
+        // check the resultIndex instead of the originalIndex so that we can stop early
+        while (resultIndex < result.size) {
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so get the next 32 bits and reset
+                currentBits = bitArray[++bitArrayIndex]
+                bitIndex = 0
+            }
+            // always copy to avoid branching as resultIndex won't increment if current element isn't included
+            result[resultIndex] = this[originalIndex++]
+            // increment the resultIndex if the current element should be included
+            val currentElement = (currentBits ushr bitIndex) and 1
+            resultIndex += currentElement
+        }
+        return ImmutableByteArray(result)
     }
 
     /**
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
-    public inline fun filterNot(predicate: (element: Byte) -> Boolean): ImmutableByteArray {
-        val result = Builder()
-        for (element in values) {
-            if (!predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filterNot(crossinline predicate: (element: Byte) -> Boolean): ImmutableByteArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> !predicate(element) }
     }
 
     /**
@@ -587,7 +622,7 @@ public value class ImmutableByteArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements having distinct keys returned by the
      * [selector]
      */
-    public inline fun <K> distinctBy(selector: (element: Byte) -> K): ImmutableByteArray {
+    public inline fun <K> distinctBy(crossinline selector: (element: Byte) -> K): ImmutableByteArray {
         if (size <= 1) return this
 
         val keys = HashSet<K>()

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableCharArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableCharArray.kt
@@ -448,46 +448,81 @@ public value class ImmutableCharArray @PublishedApi internal constructor(
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
-    public inline fun filter(predicate: (element: Char) -> Boolean): ImmutableCharArray {
-        val result = Builder()
-        for (element in values) {
-            if (predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filter(crossinline predicate: (element: Char) -> Boolean): ImmutableCharArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> predicate(element) }
     }
 
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
+     *
+     * Warning: This code is quite dense because it's highly optimized to reduce the temporary
+     * memory overhead and also dramatically improves performance due to branch elimination and
+     * a perfectly-sized result.
      */
-    public inline fun filterIndexed(predicate: (index: Int, element: Char) -> Boolean): ImmutableCharArray {
-        val result = Builder()
-        forEachIndexed { index, element ->
-            if (predicate(index, element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
+    public fun filterIndexed(predicate: (index: Int, element: Char) -> Boolean): ImmutableCharArray {
+        if (isEmpty()) return this
 
-        return result.build()
+        // divide by 32 rounding up
+        val bitArraySize = (size + 31) ushr 5
+        // store an array of int values whose 1-bits capture which elements pass the predicate
+        val bitArray = IntArray(bitArraySize)
+
+        var resultSize = 0
+        // the bit index into the current 32-bit int
+        var bitIndex = -1 // start at -1 as it gets incremented right away in the loop
+        var bitArrayIndex = 0
+        var currentBits = 0 // the current 32-bits with no elements yet
+        forEachIndexed { index, element ->
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so store them and reset
+                bitArray[bitArrayIndex++] = currentBits
+                currentBits = 0
+                bitIndex = 0
+            }
+            // jit turns this into a branchless operation
+            val currentElement = if (predicate(index, element)) 1 else 0
+
+            // conditionally increase the size without branching
+            resultSize += currentElement
+
+            // conditionally include the current element without branching
+            currentBits = currentBits or (currentElement shl bitIndex)
+        }
+        if (resultSize == 0) return EMPTY
+        if (resultSize == size) return this
+
+        // store the last set of partially-filled bits
+        bitArray[bitArrayIndex] = currentBits
+
+        val result = CharArray(resultSize)
+        var resultIndex = 0
+        bitArrayIndex = 0
+        bitIndex = -1
+        currentBits = bitArray[0]
+        var originalIndex = 0
+        // check the resultIndex instead of the originalIndex so that we can stop early
+        while (resultIndex < result.size) {
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so get the next 32 bits and reset
+                currentBits = bitArray[++bitArrayIndex]
+                bitIndex = 0
+            }
+            // always copy to avoid branching as resultIndex won't increment if current element isn't included
+            result[resultIndex] = this[originalIndex++]
+            // increment the resultIndex if the current element should be included
+            val currentElement = (currentBits ushr bitIndex) and 1
+            resultIndex += currentElement
+        }
+        return ImmutableCharArray(result)
     }
 
     /**
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
-    public inline fun filterNot(predicate: (element: Char) -> Boolean): ImmutableCharArray {
-        val result = Builder()
-        for (element in values) {
-            if (!predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filterNot(crossinline predicate: (element: Char) -> Boolean): ImmutableCharArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> !predicate(element) }
     }
 
     /**
@@ -587,7 +622,7 @@ public value class ImmutableCharArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements having distinct keys returned by the
      * [selector]
      */
-    public inline fun <K> distinctBy(selector: (element: Char) -> K): ImmutableCharArray {
+    public inline fun <K> distinctBy(crossinline selector: (element: Char) -> K): ImmutableCharArray {
         if (size <= 1) return this
 
         val keys = HashSet<K>()

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableDoubleArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableDoubleArray.kt
@@ -447,46 +447,81 @@ public value class ImmutableDoubleArray @PublishedApi internal constructor(
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
-    public inline fun filter(predicate: (element: Double) -> Boolean): ImmutableDoubleArray {
-        val result = Builder()
-        for (element in values) {
-            if (predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filter(crossinline predicate: (element: Double) -> Boolean): ImmutableDoubleArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> predicate(element) }
     }
 
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
+     *
+     * Warning: This code is quite dense because it's highly optimized to reduce the temporary
+     * memory overhead and also dramatically improves performance due to branch elimination and
+     * a perfectly-sized result.
      */
-    public inline fun filterIndexed(predicate: (index: Int, element: Double) -> Boolean): ImmutableDoubleArray {
-        val result = Builder()
-        forEachIndexed { index, element ->
-            if (predicate(index, element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
+    public fun filterIndexed(predicate: (index: Int, element: Double) -> Boolean): ImmutableDoubleArray {
+        if (isEmpty()) return this
 
-        return result.build()
+        // divide by 32 rounding up
+        val bitArraySize = (size + 31) ushr 5
+        // store an array of int values whose 1-bits capture which elements pass the predicate
+        val bitArray = IntArray(bitArraySize)
+
+        var resultSize = 0
+        // the bit index into the current 32-bit int
+        var bitIndex = -1 // start at -1 as it gets incremented right away in the loop
+        var bitArrayIndex = 0
+        var currentBits = 0 // the current 32-bits with no elements yet
+        forEachIndexed { index, element ->
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so store them and reset
+                bitArray[bitArrayIndex++] = currentBits
+                currentBits = 0
+                bitIndex = 0
+            }
+            // jit turns this into a branchless operation
+            val currentElement = if (predicate(index, element)) 1 else 0
+
+            // conditionally increase the size without branching
+            resultSize += currentElement
+
+            // conditionally include the current element without branching
+            currentBits = currentBits or (currentElement shl bitIndex)
+        }
+        if (resultSize == 0) return EMPTY
+        if (resultSize == size) return this
+
+        // store the last set of partially-filled bits
+        bitArray[bitArrayIndex] = currentBits
+
+        val result = DoubleArray(resultSize)
+        var resultIndex = 0
+        bitArrayIndex = 0
+        bitIndex = -1
+        currentBits = bitArray[0]
+        var originalIndex = 0
+        // check the resultIndex instead of the originalIndex so that we can stop early
+        while (resultIndex < result.size) {
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so get the next 32 bits and reset
+                currentBits = bitArray[++bitArrayIndex]
+                bitIndex = 0
+            }
+            // always copy to avoid branching as resultIndex won't increment if current element isn't included
+            result[resultIndex] = this[originalIndex++]
+            // increment the resultIndex if the current element should be included
+            val currentElement = (currentBits ushr bitIndex) and 1
+            resultIndex += currentElement
+        }
+        return ImmutableDoubleArray(result)
     }
 
     /**
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
-    public inline fun filterNot(predicate: (element: Double) -> Boolean): ImmutableDoubleArray {
-        val result = Builder()
-        for (element in values) {
-            if (!predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filterNot(crossinline predicate: (element: Double) -> Boolean): ImmutableDoubleArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> !predicate(element) }
     }
 
     /**
@@ -586,7 +621,7 @@ public value class ImmutableDoubleArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements having distinct keys returned by the
      * [selector]
      */
-    public inline fun <K> distinctBy(selector: (element: Double) -> K): ImmutableDoubleArray {
+    public inline fun <K> distinctBy(crossinline selector: (element: Double) -> K): ImmutableDoubleArray {
         if (size <= 1) return this
 
         val keys = HashSet<K>()

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableFloatArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableFloatArray.kt
@@ -447,46 +447,81 @@ public value class ImmutableFloatArray @PublishedApi internal constructor(
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
-    public inline fun filter(predicate: (element: Float) -> Boolean): ImmutableFloatArray {
-        val result = Builder()
-        for (element in values) {
-            if (predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filter(crossinline predicate: (element: Float) -> Boolean): ImmutableFloatArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> predicate(element) }
     }
 
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
+     *
+     * Warning: This code is quite dense because it's highly optimized to reduce the temporary
+     * memory overhead and also dramatically improves performance due to branch elimination and
+     * a perfectly-sized result.
      */
-    public inline fun filterIndexed(predicate: (index: Int, element: Float) -> Boolean): ImmutableFloatArray {
-        val result = Builder()
-        forEachIndexed { index, element ->
-            if (predicate(index, element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
+    public fun filterIndexed(predicate: (index: Int, element: Float) -> Boolean): ImmutableFloatArray {
+        if (isEmpty()) return this
 
-        return result.build()
+        // divide by 32 rounding up
+        val bitArraySize = (size + 31) ushr 5
+        // store an array of int values whose 1-bits capture which elements pass the predicate
+        val bitArray = IntArray(bitArraySize)
+
+        var resultSize = 0
+        // the bit index into the current 32-bit int
+        var bitIndex = -1 // start at -1 as it gets incremented right away in the loop
+        var bitArrayIndex = 0
+        var currentBits = 0 // the current 32-bits with no elements yet
+        forEachIndexed { index, element ->
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so store them and reset
+                bitArray[bitArrayIndex++] = currentBits
+                currentBits = 0
+                bitIndex = 0
+            }
+            // jit turns this into a branchless operation
+            val currentElement = if (predicate(index, element)) 1 else 0
+
+            // conditionally increase the size without branching
+            resultSize += currentElement
+
+            // conditionally include the current element without branching
+            currentBits = currentBits or (currentElement shl bitIndex)
+        }
+        if (resultSize == 0) return EMPTY
+        if (resultSize == size) return this
+
+        // store the last set of partially-filled bits
+        bitArray[bitArrayIndex] = currentBits
+
+        val result = FloatArray(resultSize)
+        var resultIndex = 0
+        bitArrayIndex = 0
+        bitIndex = -1
+        currentBits = bitArray[0]
+        var originalIndex = 0
+        // check the resultIndex instead of the originalIndex so that we can stop early
+        while (resultIndex < result.size) {
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so get the next 32 bits and reset
+                currentBits = bitArray[++bitArrayIndex]
+                bitIndex = 0
+            }
+            // always copy to avoid branching as resultIndex won't increment if current element isn't included
+            result[resultIndex] = this[originalIndex++]
+            // increment the resultIndex if the current element should be included
+            val currentElement = (currentBits ushr bitIndex) and 1
+            resultIndex += currentElement
+        }
+        return ImmutableFloatArray(result)
     }
 
     /**
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
-    public inline fun filterNot(predicate: (element: Float) -> Boolean): ImmutableFloatArray {
-        val result = Builder()
-        for (element in values) {
-            if (!predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filterNot(crossinline predicate: (element: Float) -> Boolean): ImmutableFloatArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> !predicate(element) }
     }
 
     /**
@@ -586,7 +621,7 @@ public value class ImmutableFloatArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements having distinct keys returned by the
      * [selector]
      */
-    public inline fun <K> distinctBy(selector: (element: Float) -> K): ImmutableFloatArray {
+    public inline fun <K> distinctBy(crossinline selector: (element: Float) -> K): ImmutableFloatArray {
         if (size <= 1) return this
 
         val keys = HashSet<K>()

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableIntArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableIntArray.kt
@@ -447,46 +447,81 @@ public value class ImmutableIntArray @PublishedApi internal constructor(
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
-    public inline fun filter(predicate: (element: Int) -> Boolean): ImmutableIntArray {
-        val result = Builder()
-        for (element in values) {
-            if (predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filter(crossinline predicate: (element: Int) -> Boolean): ImmutableIntArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> predicate(element) }
     }
 
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
+     *
+     * Warning: This code is quite dense because it's highly optimized to reduce the temporary
+     * memory overhead and also dramatically improves performance due to branch elimination and
+     * a perfectly-sized result.
      */
-    public inline fun filterIndexed(predicate: (index: Int, element: Int) -> Boolean): ImmutableIntArray {
-        val result = Builder()
-        forEachIndexed { index, element ->
-            if (predicate(index, element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
+    public fun filterIndexed(predicate: (index: Int, element: Int) -> Boolean): ImmutableIntArray {
+        if (isEmpty()) return this
 
-        return result.build()
+        // divide by 32 rounding up
+        val bitArraySize = (size + 31) ushr 5
+        // store an array of int values whose 1-bits capture which elements pass the predicate
+        val bitArray = IntArray(bitArraySize)
+
+        var resultSize = 0
+        // the bit index into the current 32-bit int
+        var bitIndex = -1 // start at -1 as it gets incremented right away in the loop
+        var bitArrayIndex = 0
+        var currentBits = 0 // the current 32-bits with no elements yet
+        forEachIndexed { index, element ->
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so store them and reset
+                bitArray[bitArrayIndex++] = currentBits
+                currentBits = 0
+                bitIndex = 0
+            }
+            // jit turns this into a branchless operation
+            val currentElement = if (predicate(index, element)) 1 else 0
+
+            // conditionally increase the size without branching
+            resultSize += currentElement
+
+            // conditionally include the current element without branching
+            currentBits = currentBits or (currentElement shl bitIndex)
+        }
+        if (resultSize == 0) return EMPTY
+        if (resultSize == size) return this
+
+        // store the last set of partially-filled bits
+        bitArray[bitArrayIndex] = currentBits
+
+        val result = IntArray(resultSize)
+        var resultIndex = 0
+        bitArrayIndex = 0
+        bitIndex = -1
+        currentBits = bitArray[0]
+        var originalIndex = 0
+        // check the resultIndex instead of the originalIndex so that we can stop early
+        while (resultIndex < result.size) {
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so get the next 32 bits and reset
+                currentBits = bitArray[++bitArrayIndex]
+                bitIndex = 0
+            }
+            // always copy to avoid branching as resultIndex won't increment if current element isn't included
+            result[resultIndex] = this[originalIndex++]
+            // increment the resultIndex if the current element should be included
+            val currentElement = (currentBits ushr bitIndex) and 1
+            resultIndex += currentElement
+        }
+        return ImmutableIntArray(result)
     }
 
     /**
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
-    public inline fun filterNot(predicate: (element: Int) -> Boolean): ImmutableIntArray {
-        val result = Builder()
-        for (element in values) {
-            if (!predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filterNot(crossinline predicate: (element: Int) -> Boolean): ImmutableIntArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> !predicate(element) }
     }
 
     /**
@@ -586,7 +621,7 @@ public value class ImmutableIntArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements having distinct keys returned by the
      * [selector]
      */
-    public inline fun <K> distinctBy(selector: (element: Int) -> K): ImmutableIntArray {
+    public inline fun <K> distinctBy(crossinline selector: (element: Int) -> K): ImmutableIntArray {
         if (size <= 1) return this
 
         val keys = HashSet<K>()

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableLongArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableLongArray.kt
@@ -447,46 +447,81 @@ public value class ImmutableLongArray @PublishedApi internal constructor(
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
-    public inline fun filter(predicate: (element: Long) -> Boolean): ImmutableLongArray {
-        val result = Builder()
-        for (element in values) {
-            if (predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filter(crossinline predicate: (element: Long) -> Boolean): ImmutableLongArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> predicate(element) }
     }
 
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
+     *
+     * Warning: This code is quite dense because it's highly optimized to reduce the temporary
+     * memory overhead and also dramatically improves performance due to branch elimination and
+     * a perfectly-sized result.
      */
-    public inline fun filterIndexed(predicate: (index: Int, element: Long) -> Boolean): ImmutableLongArray {
-        val result = Builder()
-        forEachIndexed { index, element ->
-            if (predicate(index, element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
+    public fun filterIndexed(predicate: (index: Int, element: Long) -> Boolean): ImmutableLongArray {
+        if (isEmpty()) return this
 
-        return result.build()
+        // divide by 32 rounding up
+        val bitArraySize = (size + 31) ushr 5
+        // store an array of int values whose 1-bits capture which elements pass the predicate
+        val bitArray = IntArray(bitArraySize)
+
+        var resultSize = 0
+        // the bit index into the current 32-bit int
+        var bitIndex = -1 // start at -1 as it gets incremented right away in the loop
+        var bitArrayIndex = 0
+        var currentBits = 0 // the current 32-bits with no elements yet
+        forEachIndexed { index, element ->
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so store them and reset
+                bitArray[bitArrayIndex++] = currentBits
+                currentBits = 0
+                bitIndex = 0
+            }
+            // jit turns this into a branchless operation
+            val currentElement = if (predicate(index, element)) 1 else 0
+
+            // conditionally increase the size without branching
+            resultSize += currentElement
+
+            // conditionally include the current element without branching
+            currentBits = currentBits or (currentElement shl bitIndex)
+        }
+        if (resultSize == 0) return EMPTY
+        if (resultSize == size) return this
+
+        // store the last set of partially-filled bits
+        bitArray[bitArrayIndex] = currentBits
+
+        val result = LongArray(resultSize)
+        var resultIndex = 0
+        bitArrayIndex = 0
+        bitIndex = -1
+        currentBits = bitArray[0]
+        var originalIndex = 0
+        // check the resultIndex instead of the originalIndex so that we can stop early
+        while (resultIndex < result.size) {
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so get the next 32 bits and reset
+                currentBits = bitArray[++bitArrayIndex]
+                bitIndex = 0
+            }
+            // always copy to avoid branching as resultIndex won't increment if current element isn't included
+            result[resultIndex] = this[originalIndex++]
+            // increment the resultIndex if the current element should be included
+            val currentElement = (currentBits ushr bitIndex) and 1
+            resultIndex += currentElement
+        }
+        return ImmutableLongArray(result)
     }
 
     /**
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
-    public inline fun filterNot(predicate: (element: Long) -> Boolean): ImmutableLongArray {
-        val result = Builder()
-        for (element in values) {
-            if (!predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filterNot(crossinline predicate: (element: Long) -> Boolean): ImmutableLongArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> !predicate(element) }
     }
 
     /**
@@ -586,7 +621,7 @@ public value class ImmutableLongArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements having distinct keys returned by the
      * [selector]
      */
-    public inline fun <K> distinctBy(selector: (element: Long) -> K): ImmutableLongArray {
+    public inline fun <K> distinctBy(crossinline selector: (element: Long) -> K): ImmutableLongArray {
         if (size <= 1) return this
 
         val keys = HashSet<K>()

--- a/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableShortArray.kt
+++ b/immutable-arrays/core/src/main/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableShortArray.kt
@@ -448,46 +448,81 @@ public value class ImmutableShortArray @PublishedApi internal constructor(
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
      */
-    public inline fun filter(predicate: (element: Short) -> Boolean): ImmutableShortArray {
-        val result = Builder()
-        for (element in values) {
-            if (predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filter(crossinline predicate: (element: Short) -> Boolean): ImmutableShortArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> predicate(element) }
     }
 
     /**
      * Returns an immutable array containing only the elements matching the given [predicate].
+     *
+     * Warning: This code is quite dense because it's highly optimized to reduce the temporary
+     * memory overhead and also dramatically improves performance due to branch elimination and
+     * a perfectly-sized result.
      */
-    public inline fun filterIndexed(predicate: (index: Int, element: Short) -> Boolean): ImmutableShortArray {
-        val result = Builder()
-        forEachIndexed { index, element ->
-            if (predicate(index, element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
+    public fun filterIndexed(predicate: (index: Int, element: Short) -> Boolean): ImmutableShortArray {
+        if (isEmpty()) return this
 
-        return result.build()
+        // divide by 32 rounding up
+        val bitArraySize = (size + 31) ushr 5
+        // store an array of int values whose 1-bits capture which elements pass the predicate
+        val bitArray = IntArray(bitArraySize)
+
+        var resultSize = 0
+        // the bit index into the current 32-bit int
+        var bitIndex = -1 // start at -1 as it gets incremented right away in the loop
+        var bitArrayIndex = 0
+        var currentBits = 0 // the current 32-bits with no elements yet
+        forEachIndexed { index, element ->
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so store them and reset
+                bitArray[bitArrayIndex++] = currentBits
+                currentBits = 0
+                bitIndex = 0
+            }
+            // jit turns this into a branchless operation
+            val currentElement = if (predicate(index, element)) 1 else 0
+
+            // conditionally increase the size without branching
+            resultSize += currentElement
+
+            // conditionally include the current element without branching
+            currentBits = currentBits or (currentElement shl bitIndex)
+        }
+        if (resultSize == 0) return EMPTY
+        if (resultSize == size) return this
+
+        // store the last set of partially-filled bits
+        bitArray[bitArrayIndex] = currentBits
+
+        val result = ShortArray(resultSize)
+        var resultIndex = 0
+        bitArrayIndex = 0
+        bitIndex = -1
+        currentBits = bitArray[0]
+        var originalIndex = 0
+        // check the resultIndex instead of the originalIndex so that we can stop early
+        while (resultIndex < result.size) {
+            if (++bitIndex == 32) {
+                // reached the end of the current bits so get the next 32 bits and reset
+                currentBits = bitArray[++bitArrayIndex]
+                bitIndex = 0
+            }
+            // always copy to avoid branching as resultIndex won't increment if current element isn't included
+            result[resultIndex] = this[originalIndex++]
+            // increment the resultIndex if the current element should be included
+            val currentElement = (currentBits ushr bitIndex) and 1
+            resultIndex += currentElement
+        }
+        return ImmutableShortArray(result)
     }
 
     /**
      * Returns an immutable array containing only the elements that don't match the [predicate].
      */
-    public inline fun filterNot(predicate: (element: Short) -> Boolean): ImmutableShortArray {
-        val result = Builder()
-        for (element in values) {
-            if (!predicate(element)) {
-                result.add(element)
-            }
-        }
-        if (result.size == size) return this
-
-        return result.build()
+    public inline fun filterNot(crossinline predicate: (element: Short) -> Boolean): ImmutableShortArray {
+        // delegate to filterIndexed as that's extremely optimized
+        return filterIndexed { _, element -> !predicate(element) }
     }
 
     /**
@@ -587,7 +622,7 @@ public value class ImmutableShortArray @PublishedApi internal constructor(
      * Returns an immutable array containing only the elements having distinct keys returned by the
      * [selector]
      */
-    public inline fun <K> distinctBy(selector: (element: Short) -> K): ImmutableShortArray {
+    public inline fun <K> distinctBy(crossinline selector: (element: Short) -> K): ImmutableShortArray {
         if (size <= 1) return this
 
         val keys = HashSet<K>()

--- a/immutable-arrays/core/src/test/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrayTest.kt
+++ b/immutable-arrays/core/src/test/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableArrayTest.kt
@@ -940,6 +940,15 @@ class ImmutableArrayTest {
             expectThat(filter { it.isNotEmpty() }.referencesSameArrayAs(this))
                 .isTrue()
         }
+
+        // fuzz testing ensuring that the behavior matches regular arrays since the implementation is complex
+        repeat(100) {
+            val size = Random.nextInt(from = 0, until = 200)
+            val randomValues = Array(size) { Random.nextInt() }
+
+            expectThat(randomValues.toImmutableArray<Int>().filter { it % 2 == 0 }.asList())
+                .isEqualTo(randomValues.filter { it % 2 == 0 })
+        }
     }
 
     @Test
@@ -959,6 +968,16 @@ class ImmutableArrayTest {
                     .referencesSameArrayAs(this),
             ).isTrue()
         }
+
+        // fuzz testing ensuring that the behavior matches regular arrays since the implementation is complex
+        repeat(100) {
+            val size = Random.nextInt(from = 0, until = 200)
+            val randomValues = Array(size) { Random.nextInt() }
+
+            expectThat(
+                randomValues.toImmutableArray<Int>().filterIndexed { index, value -> (index + value) % 2 == 0 }.asList(),
+            ).isEqualTo(randomValues.filterIndexed { index, value -> (index + value) % 2 == 0 })
+        }
     }
 
     @Test
@@ -975,6 +994,15 @@ class ImmutableArrayTest {
 
             expectThat(filterNot { it.isEmpty() }.referencesSameArrayAs(this))
                 .isTrue()
+        }
+
+        // fuzz testing ensuring that the behavior matches regular arrays since the implementation is complex
+        repeat(100) {
+            val size = Random.nextInt(from = 0, until = 200)
+            val randomValues = Array(size) { Random.nextInt() }
+
+            expectThat(randomValues.toImmutableArray<Int>().filterNot { it % 2 == 0 }.asList())
+                .isEqualTo(randomValues.filterNot { it % 2 == 0 })
         }
     }
 

--- a/immutable-arrays/core/src/test/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableIntArrayTest.kt
+++ b/immutable-arrays/core/src/test/kotlin/com/danrusu/pods4k/immutableArrays/ImmutableIntArrayTest.kt
@@ -986,6 +986,15 @@ class ImmutableIntArrayTest {
             expectThat(filter { it >= 0 }.referencesSameArrayAs(this))
                 .isTrue()
         }
+
+        // fuzz testing ensuring that the behavior matches regular arrays since the implementation is complex
+        repeat(100) {
+            val size = Random.nextInt(from = 0, until = 200)
+            val randomValues = IntArray(size) { Random.nextInt() }
+
+            expectThat(randomValues.toImmutableArray().filter { it % 2 == 0 }.asList())
+                .isEqualTo(randomValues.filter { it % 2 == 0 })
+        }
     }
 
     @Test
@@ -1005,6 +1014,16 @@ class ImmutableIntArrayTest {
                     .referencesSameArrayAs(this),
             ).isTrue()
         }
+
+        // fuzz testing ensuring that the behavior matches regular arrays since the implementation is complex
+        repeat(100) {
+            val size = Random.nextInt(from = 0, until = 200)
+            val randomValues = IntArray(size) { Random.nextInt() }
+
+            expectThat(
+                randomValues.toImmutableArray().filterIndexed { index, value -> (index + value) % 2 == 0 }.asList(),
+            ).isEqualTo(randomValues.filterIndexed { index, value -> (index + value) % 2 == 0 })
+        }
     }
 
     @Test
@@ -1021,6 +1040,15 @@ class ImmutableIntArrayTest {
 
             expectThat(filterNot { it < 0 }.referencesSameArrayAs(this))
                 .isTrue()
+        }
+
+        // fuzz testing ensuring that the behavior matches regular arrays since the implementation is complex
+        repeat(100) {
+            val size = Random.nextInt(from = 0, until = 200)
+            val randomValues = IntArray(size) { Random.nextInt() }
+
+            expectThat(randomValues.toImmutableArray().filterNot { it % 2 == 0 }.asList())
+                .isEqualTo(randomValues.filterNot { it % 2 == 0 })
         }
     }
 


### PR DESCRIPTION
This reduces the temporary memory consumption and uses bitwise operations to eliminate branches and significantly improve performance according to JMH benchmarks (readme will be updated with results shortly after).

### Memory Efficiency

Filtering elements into a builder with a dynamically-growing array almost always ends up with unused capacity so the elements need to be copied into a smaller perfectly-sized array.  However, it also encountered several resizing operations along the way.  

For example, since the builder doesn't know the resulting size, accumulating 50 elements ends up using 136 elements of  temporary space due to several resizing operations (10 -> 15 -> 23 -> 35 -> 53) using over 2X as much temporary memory as the resulting size.  If the resulting size is 100 elements then it used over 3X as much temporary memory along the way!

This PR takes a different approach by using an `IntArray` to capture which elements are included as individual bits so an int represents 32 values.  This results in the following overhead of storing these bits depending on the data type being filtered:

| Data Type                                    | Overhead (1 bit per element / # datatype bits) |
|------------------------------------|----------------------------------------------------|
| Boolean & Byte                           | 12.5%                                                                 |
| Char & Short                               | 6.3%                                                                   |
| Int & Float                                   | 3.1%                                                                   |
| Double & Long                           | 1.6%                                                                   |
| References                                  | 1.6%                                                                   |
| References - Compressed oops  | 3.1%                                                                   |

So given the over 2X overhead due to the multiplicative nature of repeated resizing of the builder buffer, the new approach uses less temporary memory as long as filtering maintains more than about 6% of the original elements (for Boolean & Bytes) and 3% for the other data types.  I expect that filtering retains much more than 3% of elements on average so the temporary memory is reduced quite dramatically with the new approach.

As a reference, the alternative approach of making the buffer the same size as the original array has a 100% temporary memory  overhead so this is about 30 times more efficient than that on average.